### PR TITLE
Fixed to double bracket for reference list

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -142,10 +142,10 @@
 @book{american2019publication,
   title={{Publication Manual of the American Psychological Association}},
   edition = {7th Edition},
-  author={American Psychological Association and others},
+  author={{American Psychological Association and others}},
   year={2019},
   isbn={1433832178},
-  publisher={American Psychological Association}
+  publisher={{American Psychological Association}}
 }
 
 


### PR DESCRIPTION
Related to: https://github.com/openjournals/joss-reviews/issues/3236

The double `{{name}}` bib syntax needed to display full author name.