### PR TITLE
chore: migrate from pre-commit to prek

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -42,6 +42,7 @@ README.html
 ^doc$
 ^docs$
 ^hextools/.
+^lychee\.toml$
 ^man-roxygen$
 ^old/.
 ^paper.*$

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,10 +2,10 @@ on:
   pull_request:
     branches: [main, master]
 
-name: pre-commit
+name: prek
 
 jobs:
-  pre-commit:
-    uses: IndrajeetPatil/workflows/.github/workflows/pre-commit.yaml@main
+  prek:
+    uses: IndrajeetPatil/workflows/.github/workflows/pre-commit.yaml@chore/migrate-to-prek
     permissions:
       contents: write

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,6 +6,6 @@ name: prek
 
 jobs:
   prek:
-    uses: IndrajeetPatil/workflows/.github/workflows/pre-commit.yaml@chore/migrate-to-prek
+    uses: IndrajeetPatil/workflows/.github/workflows/pre-commit.yaml@main
     permissions:
       contents: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,30 +1,48 @@
-# All available hooks: https://pre-commit.com/hooks.html
+# All available hooks: https://prek.j178.dev/builtin/
 # R specific hooks: https://github.com/lorenzwalthert/precommit
-default_stages: [pre-commit, pre-push, commit-msg]
+minimum_prek_version: "0.3.8"
+
+default_stages: [pre-commit, pre-push]
+
 default_language_version:
   python: python3
 
+# Exclude auto-generated and snapshot files from all hooks
+exclude: >
+  (?x)^(
+  man/.*|
+  tests/testthat/_snaps/.*|
+  )$
+
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+  - repo: builtin
     hooks:
-      - id: check-added-large-files
-      - id: check-json
-      - id: check-yaml
+      # File formatting
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
       - id: mixed-line-ending
+      - id: fix-byte-order-marker
+      # File validation
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-illegal-windows-names
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: check-xml
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      # Security
+      - id: detect-private-key
+      # Git hygiene
+      - id: no-commit-to-branch
+        args: [--branch, main, --branch, master]
+      # Sorting
       - id: file-contents-sorter
         files: "\\.Rbuildignore$"
-      - id: end-of-file-fixer
-        exclude: >
-          (?x)^(
-          man/.*|
-          tests/testthat/_snaps/.*\.md|
-          )$
 
   - repo: https://github.com/lorenzwalthert/gitignore-tidy
     rev: "0.1.3"
     hooks:
       - id: tidy-gitignore
-
-ci:
-  autoupdate_schedule: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ exclude: >
   (?x)^(
   man/.*|
   tests/testthat/_snaps/.*|
-  README\.md|
+  README\.md
   )$
 
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ exclude: >
   (?x)^(
   man/.*|
   tests/testthat/_snaps/.*|
+  README\.md|
   )$
 
 repos:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: statsExpressions
 Title: Tidy Dataframes and Expressions with Statistical Details
 Version: 1.7.3
-Authors@R: 
+Authors@R:
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = c("cre", "aut", "cph"),
            comment = c(ORCID = "0000-0003-1995-6531"))
 Maintainer: Indrajeet Patil <patilindrajeet.science@gmail.com>
@@ -19,7 +19,7 @@ License: MIT + file LICENSE
 URL: https://indrajeetpatil.github.io/statsExpressions/,
     https://github.com/IndrajeetPatil/statsExpressions
 BugReports: https://github.com/IndrajeetPatil/statsExpressions/issues
-Depends: 
+Depends:
     R (>= 4.3.0),
     stats
 Imports:
@@ -54,7 +54,7 @@ Suggests:
     survival,
     testthat (>= 3.3.2),
     utils
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 Config/Needs/check: anthonynorth/roxyglobals
 Config/roxyglobals/unique: TRUE

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,9 @@ format:
 
 lint:
 	Rscript -e 'lintr::lint_package()'
+
+hooks:
+	prek run --all-files
+
+hooks_install:
+	prek install

--- a/NEWS.md
+++ b/NEWS.md
@@ -485,7 +485,7 @@ BUG FIXES
 # statsExpressions 0.3.1
 
 ## NEW FEATURES
- 
+
   - Adds a new function `corr_objects` to reduce dependency load of
     `ggstatsplot`. This is an experimental function and should be avoided until
     it stabilizes.

--- a/README.Rmd
+++ b/README.Rmd
@@ -25,10 +25,10 @@ suppressPackageStartupMessages(library(statsExpressions))
 # `{statsExpressions}`: Tidy dataframes and expressions with statistical details
 
 Status | Usage | Miscellaneous
------------------ | ----------------- | ----------------- 
+----------------- | ----------------- | -----------------
 [![R build status](https://github.com/IndrajeetPatil/statsExpressions/workflows/R-CMD-check/badge.svg)](https://github.com/IndrajeetPatil/statsExpressions/actions) | [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/statsExpressions?color=blue)](https://CRAN.R-project.org/package=statsExpressions) | [![Codecov](https://codecov.io/gh/IndrajeetPatil/statsExpressions/branch/main/graph/badge.svg)](https://app.codecov.io/gh/IndrajeetPatil/statsExpressions?branch=main)
-[![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html) | [![Daily downloads](https://cranlogs.r-pkg.org/badges/last-day/statsExpressions?color=blue)](https://CRAN.R-project.org/package=statsExpressions) | [![DOI](https://joss.theoj.org/papers/10.21105/joss.03236/status.svg)](https://doi.org/10.21105/joss.03236) 
- 
+[![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html) | [![Daily downloads](https://cranlogs.r-pkg.org/badges/last-day/statsExpressions?color=blue)](https://CRAN.R-project.org/package=statsExpressions) | [![DOI](https://joss.theoj.org/papers/10.21105/joss.03236/status.svg)](https://doi.org/10.21105/joss.03236)
+
 # Introduction <img src="man/figures/logo.png" alt="statsExpressions package logo" align="right" width="240" />
 
 ```{r, child = "man/rmd-fragments/statsExpressions-package.Rmd"}
@@ -106,7 +106,7 @@ mtcars %>%
 ```
 
 These functions are also compatible with other popular data manipulation
-packages. 
+packages.
 
 For example, let's say we want to run a one-sample *t*-test for all levels of a
 certain grouping variable. We can use `dplyr` to do so:
@@ -164,7 +164,7 @@ Here are a few examples for supported analyses.
 
 ## Expressions for one-way ANOVAs
 
-The returned data frame will always have a column called `expression`. 
+The returned data frame will always have a column called `expression`.
 
 Assuming there is only a single result you need to display in a plot, to use it in a plot, you have two options:
 
@@ -432,7 +432,7 @@ more about how one-way (between-subjects) ANOVA, you can run
 ```{r, child = "man/rmd-fragments/oneway_anova.Rmd"}
 ```
 
-## `two_sample_test` 
+## `two_sample_test`
 
 ```{r, child = "man/rmd-fragments/two_sample_test.Rmd"}
 ```
@@ -481,5 +481,5 @@ Development, Berlin).
 Bug reports, suggestions, questions, and (most of all)
 contributions are welcome.
 
-Please note that this project is released with a 
+Please note that this project is released with a
 [Contributor Code of Conduct](https://www.contributor-covenant.org/version/3/0/code_of_conduct/). By participating in this project you agree to abide by its terms.

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,3 @@
+# Exclude data: URIs (e.g. data:font/woff;base64,...) — these are inline binary
+# blobs, not real links, and make CI logs unscrollable when reported.
+exclude = ["^data:"]

--- a/paper/JOSS files/paper.Rmd
+++ b/paper/JOSS files/paper.Rmd
@@ -104,7 +104,7 @@ with missing data. Moreover, they always return a dataframe that can be further
 utilized downstream in the workflow (such as visualization).
 
 Function | Parametric | Non-parametric | Robust | Bayesian
------------------- | ---- | ----- | ----| ----- 
+------------------ | ---- | ----- | ----| -----
 `one_sample_test` | \checkmark | \checkmark | \checkmark | \checkmark
 `two_sample_test` | \checkmark | \checkmark | \checkmark | \checkmark
 `oneway_anova` | \checkmark | \checkmark | \checkmark | \checkmark

--- a/vignettes/stats_details.Rmd
+++ b/vignettes/stats_details.Rmd
@@ -61,7 +61,7 @@ more about how one-way (between-subjects) ANOVA, you can run
 ```{r child="../man/rmd-fragments/oneway_anova.Rmd"}
 ```
 
-### `two_sample_test()` 
+### `two_sample_test()`
 
 ```{r child="../man/rmd-fragments/two_sample_test.Rmd"}
 ```
@@ -106,5 +106,5 @@ to interpret effect sizes:
 
 ## Suggestions
 
-If you find any bugs or have any suggestions/remarks, please file an issue on GitHub: 
+If you find any bugs or have any suggestions/remarks, please file an issue on GitHub:
 <https://github.com/IndrajeetPatil/statsExpressions/issues>


### PR DESCRIPTION
## Summary

Replaces [pre-commit](https://pre-commit.com/) with [prek](https://github.com/j178/prek) — a fast, Rust-native drop-in replacement that reads the same `.pre-commit-config.yaml` format.

## Changes

### `.pre-commit-config.yaml`
- Add `minimum_prek_version: "0.3.8"`
- Replace `repo: https://github.com/pre-commit/pre-commit-hooks` with `repo: builtin` — prek's Rust-native implementations (no Python runtime, no network, instant startup)
- Expand built-in hooks applicable to R projects:
  - **New:** `trailing-whitespace`, `fix-byte-order-marker`, `check-case-conflict`, `check-illegal-windows-names`, `check-toml`, `check-xml`, `check-merge-conflict`, `check-symlinks`, `destroyed-symlinks`, `detect-private-key`, `no-commit-to-branch`
  - **Kept:** `end-of-file-fixer`, `mixed-line-ending`, `check-added-large-files`, `check-json`, `check-yaml`, `file-contents-sorter`
- Set `default_language_version: python: python3` (portable; used by `gitignore-tidy` which is Python-based)
- Add top-level `exclude` pattern for auto-generated/snapshot files: `man/.*`, `tests/testthat/_snaps/.*`, `README.md` (rendered from `README.Rmd`)
- Remove `ci:` block (pre-commit.ci service config — not used by prek)
- Remove `commit-msg` from `default_stages` (no commit-msg hooks configured)
- Keep `lorenzwalthert/gitignore-tidy` (Python hook, fully supported by prek)

### `.github/workflows/pre-commit.yaml`
- Rename workflow `name:` to `prek`
- The workflow calls the shared reusable workflow from `IndrajeetPatil/workflows`, which has been updated to use `j178/prek-action@v2`

### `Makefile`
- Add `hooks` target: `prek run --all-files` — run all hooks locally
- Add `hooks_install` target: `prek install` — wire hooks into git

### `lychee.toml`
- Add `exclude = ["^data:"]` to prevent `data:font/woff;base64` URIs from being checked by lychee, which were flooding CI logs with thousands of "Unsupported" lines making them unscrollable

## Notes

- prek R language support is not yet available ([j178/prek#42](https://github.com/j178/prek/issues/42)), but current hooks do not use R language — no regression
- Install prek locally: `brew install prek` or `uv tool install prek`