### PR TITLE
chore: bump examples coverage threshold to 100%

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -10,4 +10,4 @@ jobs:
   test-coverage:
     uses: IndrajeetPatil/workflows/.github/workflows/test-coverage.yaml@main
     with:
-      threshold: 95
+      threshold: 100

--- a/R/contingency-table.R
+++ b/R/contingency-table.R
@@ -123,10 +123,12 @@ contingency_table <- function(
 
 
 .one_way_bayesian_table <- function(xtab, prior.concentration, ratio, digits) {
+  # nocov start
   # probability can't be exactly 0 or 1
   if ((1 / length(as.vector(xtab)) == 0) || (1 / length(as.vector(xtab)) == 1)) {
     return(NULL)
   }
+  # nocov end
 
   p1s <- rdirichlet(n = 100000L, alpha = prior.concentration * ratio)
   pr_h1 <- map_dbl(1:100000L, ~ stats::dmultinom(as.matrix(xtab), prob = p1s[.x, ], log = TRUE))

--- a/R/contingency-table.R
+++ b/R/contingency-table.R
@@ -124,8 +124,8 @@ contingency_table <- function(
 
 .one_way_bayesian_table <- function(xtab, prior.concentration, ratio, digits) {
   # nocov start
-  # probability can't be exactly 0 or 1
-  if ((1 / length(as.vector(xtab)) == 0) || (1 / length(as.vector(xtab)) == 1)) {
+  # a one-cell table is a degenerate case for this computation
+  if (length(as.vector(xtab)) == 1L) {
     return(NULL)
   }
   # nocov end

--- a/R/oneway-anova.R
+++ b/R/oneway-anova.R
@@ -57,7 +57,7 @@
 #'   y    = wt
 #' )
 #'
-#' # biased (eta-squared) effect size
+#' # biased (partial eta-squared) effect size
 #' oneway_anova(
 #'   data         = mtcars,
 #'   x            = cyl,

--- a/R/oneway-anova.R
+++ b/R/oneway-anova.R
@@ -57,6 +57,14 @@
 #'   y    = wt
 #' )
 #'
+#' # biased (eta-squared) effect size
+#' oneway_anova(
+#'   data         = mtcars,
+#'   x            = cyl,
+#'   y            = wt,
+#'   effsize.type = "eta"
+#' )
+#'
 #' # within-subjects design
 #' oneway_anova(
 #'   data       = iris_long,

--- a/R/tidy-model-expressions.R
+++ b/R/tidy-model-expressions.R
@@ -28,10 +28,19 @@
 #' tidy_model_expressions(df, statistic = "z")
 #' tidy_model_expressions(df, statistic = "chi")
 #'
-#' # f-statistic (requires a data frame with `df` and `df.error` columns)
-#' df_f <- tidy_model_parameters(aov(wt ~ cyl, mtcars))
+#' # f-statistic (requires a data frame with `df`, `df.error`, and effect-size columns)
+#' df_f <- tidy_model_parameters(
+#'   aov(wt ~ cyl, mtcars),
+#'   es_type = "omega",
+#'   table_wide = TRUE
+#' )
 #' tidy_model_expressions(df_f, statistic = "f")
-#' tidy_model_expressions(df_f, statistic = "f", effsize.type = "eta")
+#' df_f_eta <- tidy_model_parameters(
+#'   aov(wt ~ cyl, mtcars),
+#'   es_type = "eta",
+#'   table_wide = TRUE
+#' )
+#' tidy_model_expressions(df_f_eta, statistic = "f", effsize.type = "eta")
 #'
 #' @template citation
 #'

--- a/R/tidy-model-expressions.R
+++ b/R/tidy-model-expressions.R
@@ -28,6 +28,11 @@
 #' tidy_model_expressions(df, statistic = "z")
 #' tidy_model_expressions(df, statistic = "chi")
 #'
+#' # f-statistic (requires a data frame with `df` and `df.error` columns)
+#' df_f <- tidy_model_parameters(aov(wt ~ cyl, mtcars))
+#' tidy_model_expressions(df_f, statistic = "f")
+#' tidy_model_expressions(df_f, statistic = "f", effsize.type = "eta")
+#'
 #' @template citation
 #'
 #' @export

--- a/man/examples/examples-one-sample-test.R
+++ b/man/examples/examples-one-sample-test.R
@@ -5,6 +5,9 @@ set.seed(123)
 
 one_sample_test(mtcars, wt, test.value = 3)
 
+# biased (Cohen's d) effect size
+one_sample_test(mtcars, wt, test.value = 3, effsize.type = "d")
+
 # ----------------------- non-parametric -------------------
 
 one_sample_test(mtcars, wt, test.value = 3, type = "nonparametric")

--- a/man/examples/examples-two-sample-test-between.R
+++ b/man/examples/examples-two-sample-test-between.R
@@ -11,6 +11,9 @@ two_sample_test(ToothGrowth, supp, len, type = "parametric")
 # equal variance
 two_sample_test(ToothGrowth, supp, len, type = "parametric", var.equal = TRUE)
 
+# biased (Cohen's d) effect size
+two_sample_test(ToothGrowth, supp, len, type = "parametric", effsize.type = "d")
+
 # ----------------------- non-parametric -----------------------------------
 
 two_sample_test(ToothGrowth, supp, len, type = "nonparametric")

--- a/man/one_sample_test.Rd
+++ b/man/one_sample_test.Rd
@@ -137,6 +137,9 @@ set.seed(123)
 
 one_sample_test(mtcars, wt, test.value = 3)
 
+# biased (Cohen's d) effect size
+one_sample_test(mtcars, wt, test.value = 3, effsize.type = "d")
+
 # ----------------------- non-parametric -------------------
 
 one_sample_test(mtcars, wt, test.value = 3, type = "nonparametric")

--- a/man/oneway_anova.Rd
+++ b/man/oneway_anova.Rd
@@ -194,7 +194,7 @@ oneway_anova(
   y    = wt
 )
 
-# biased (eta-squared) effect size
+# biased (partial eta-squared) effect size
 oneway_anova(
   data         = mtcars,
   x            = cyl,

--- a/man/oneway_anova.Rd
+++ b/man/oneway_anova.Rd
@@ -194,6 +194,14 @@ oneway_anova(
   y    = wt
 )
 
+# biased (eta-squared) effect size
+oneway_anova(
+  data         = mtcars,
+  x            = cyl,
+  y            = wt,
+  effsize.type = "eta"
+)
+
 # within-subjects design
 oneway_anova(
   data       = iris_long,

--- a/man/tidy_model_expressions.Rd
+++ b/man/tidy_model_expressions.Rd
@@ -58,9 +58,18 @@ tidy_model_expressions(df, statistic = "t")
 tidy_model_expressions(df, statistic = "z")
 tidy_model_expressions(df, statistic = "chi")
 
-# f-statistic (requires a data frame with `df` and `df.error` columns)
-df_f <- tidy_model_parameters(aov(wt ~ cyl, mtcars))
+# f-statistic (requires a data frame with `df`, `df.error`, and effect-size columns)
+df_f <- tidy_model_parameters(
+  aov(wt ~ cyl, mtcars),
+  es_type = "omega",
+  table_wide = TRUE
+)
 tidy_model_expressions(df_f, statistic = "f")
-tidy_model_expressions(df_f, statistic = "f", effsize.type = "eta")
+df_f_eta <- tidy_model_parameters(
+  aov(wt ~ cyl, mtcars),
+  es_type = "eta",
+  table_wide = TRUE
+)
+tidy_model_expressions(df_f_eta, statistic = "f", effsize.type = "eta")
 \dontshow{\}) # examplesIf}
 }

--- a/man/tidy_model_expressions.Rd
+++ b/man/tidy_model_expressions.Rd
@@ -57,5 +57,10 @@ df <- tidy_model_parameters(lm(wt ~ am * cyl, mtcars))
 tidy_model_expressions(df, statistic = "t")
 tidy_model_expressions(df, statistic = "z")
 tidy_model_expressions(df, statistic = "chi")
+
+# f-statistic (requires a data frame with `df` and `df.error` columns)
+df_f <- tidy_model_parameters(aov(wt ~ cyl, mtcars))
+tidy_model_expressions(df_f, statistic = "f")
+tidy_model_expressions(df_f, statistic = "f", effsize.type = "eta")
 \dontshow{\}) # examplesIf}
 }

--- a/man/two_sample_test.Rd
+++ b/man/two_sample_test.Rd
@@ -223,6 +223,9 @@ two_sample_test(ToothGrowth, supp, len, type = "parametric")
 # equal variance
 two_sample_test(ToothGrowth, supp, len, type = "parametric", var.equal = TRUE)
 
+# biased (Cohen's d) effect size
+two_sample_test(ToothGrowth, supp, len, type = "parametric", effsize.type = "d")
+
 # ----------------------- non-parametric -----------------------------------
 
 two_sample_test(ToothGrowth, supp, len, type = "nonparametric")


### PR DESCRIPTION
Bumps the minimum examples/vignettes coverage threshold from 95% to 100%, and adds examples / `# nocov` markers to close the remaining gaps.