### PR TITLE
chore: replace old GitHub Pages domain with new custom domain

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Description: Utilities for producing dataframes with rich details for the
     package also forms the statistical processing backend for
     'ggstatsplot'. References: Patil (2021) <doi:10.21105/joss.03236>.
 License: MIT + file LICENSE
-URL: https://indrajeetpatil.github.io/statsExpressions/,
+URL: https://www.indrapatil.com/statsExpressions/,
     https://github.com/IndrajeetPatil/statsExpressions
 BugReports: https://github.com/IndrajeetPatil/statsExpressions/issues
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,7 +30,7 @@
 ## MAJOR CHANGES
 
 - _Test and effect size details_ vignette is now available only on the package
-  website (https://indrajeetpatil.github.io/statsExpressions/articles/).
+  website (https://www.indrapatil.com/statsExpressions/articles/).
 
 - Unused dataset has been removed: `movies_wide`.
 

--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -30,7 +30,7 @@
 #' ```
 #'
 #' @references For more, see:
-#' <https://indrajeetpatil.github.io/ggstatsplot/articles/web_only/pairwise.html>
+#' <https://www.indrapatil.com/ggstatsplot/articles/web_only/pairwise.html>
 #'
 #' @autoglobal
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -87,7 +87,7 @@ mtcars %>% oneway_anova(cyl, wt, type = "robust")
 ```
 
 All possible output dataframes from functions are tabulated here:
-<https://indrajeetpatil.github.io/statsExpressions/articles/web_only/dataframe_outputs.html>
+<https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html>
 
 Needless to say this will also work with the `kable` function to generate a
 table:
@@ -463,7 +463,7 @@ Note that these functions were initially written to display results from
 statistical tests on ready-made `{ggplot2}` plots implemented in `{ggstatsplot}`.
 
 For detailed documentation, see the package website:
-<https://indrajeetpatil.github.io/ggstatsplot/>
+<https://www.indrapatil.com/ggstatsplot/>
 
 Here is an example from `{ggstatsplot}` of what the plots look like when the
 expressions are displayed in the subtitle-

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ underlying packages can be accessed, with a simpler interface and no
 requirement to change data format.
 
 This package forms the statistical processing backend for
-[`ggstatsplot`](https://indrajeetpatil.github.io/ggstatsplot/) package.
+[`ggstatsplot`](https://www.indrapatil.com/ggstatsplot/) package.
 
 For more documentation, see the dedicated
-[website](https://indrajeetpatil.github.io/statsExpressions/).
+[website](https://www.indrapatil.com/statsExpressions/).
 
 # Installation
 
@@ -159,7 +159,7 @@ mtcars %>% oneway_anova(cyl, wt, type = "robust")
 ```
 
 All possible output dataframes from functions are tabulated here:
-<https://indrajeetpatil.github.io/statsExpressions/articles/web_only/dataframe_outputs.html>
+<https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html>
 
 Needless to say this will also work with the `kable` function to
 generate a table:
@@ -689,7 +689,7 @@ statistical tests on ready-made `{ggplot2}` plots implemented in
 `{ggstatsplot}`.
 
 For detailed documentation, see the package website:
-<https://indrajeetpatil.github.io/ggstatsplot/>
+<https://www.indrapatil.com/ggstatsplot/>
 
 Here is an example from `{ggstatsplot}` of what the plots look like when
 the expressions are displayed in the subtitle-

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,7 +4,7 @@
   "identifier": "statsExpressions",
   "description": "Utilities for producing dataframes with rich details for the most common types of statistical approaches and tests: parametric, nonparametric, robust, and Bayesian t-test, one-way ANOVA, correlation analyses, contingency table analyses, and meta-analyses. The functions are pipe-friendly and provide a consistent syntax to work with tidy data. These dataframes additionally contain expressions with statistical details, and can be used in graphing packages. This package also forms the statistical processing backend for 'ggstatsplot'. References: Patil (2021) <doi:10.21105/joss.03236>.",
   "name": "statsExpressions: Tidy Dataframes and Expressions with Statistical Details",
-  "relatedLink": "https://indrajeetpatil.github.io/statsExpressions/",
+  "relatedLink": "https://www.indrapatil.com/statsExpressions/",
   "codeRepository": "https://github.com/IndrajeetPatil/statsExpressions",
   "issueTracker": "https://github.com/IndrajeetPatil/statsExpressions/issues",
   "license": "https://spdx.org/licenses/MIT",

--- a/man/contingency_table.Rd
+++ b/man/contingency_table.Rd
@@ -112,7 +112,7 @@ two degrees of freedom (e.g. anova)
 \item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://indrajeetpatil.github.io/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric and Bayesian one-way and two-way contingency table analyses.

--- a/man/corr_test.Rd
+++ b/man/corr_test.Rd
@@ -83,7 +83,7 @@ two degrees of freedom (e.g. anova)
 \item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://indrajeetpatil.github.io/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric, non-parametric, robust, and Bayesian correlation test.

--- a/man/meta_analysis.Rd
+++ b/man/meta_analysis.Rd
@@ -72,7 +72,7 @@ two degrees of freedom (e.g. anova)
 \item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://indrajeetpatil.github.io/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric, non-parametric, robust, and Bayesian random-effects meta-analysis.

--- a/man/one_sample_test.Rd
+++ b/man/one_sample_test.Rd
@@ -92,7 +92,7 @@ two degrees of freedom (e.g. anova)
 \item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://indrajeetpatil.github.io/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric, non-parametric, robust, and Bayesian one-sample tests.

--- a/man/oneway_anova.Rd
+++ b/man/oneway_anova.Rd
@@ -118,7 +118,7 @@ two degrees of freedom (e.g. anova)
 \item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://indrajeetpatil.github.io/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric, non-parametric, robust, and Bayesian one-way ANOVA.

--- a/man/pairwise_comparisons.Rd
+++ b/man/pairwise_comparisons.Rd
@@ -109,7 +109,7 @@ two degrees of freedom (e.g. anova)
 \item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://indrajeetpatil.github.io/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Calculate parametric, non-parametric, robust, and Bayes Factor pairwise
@@ -270,5 +270,5 @@ pairwise_comparisons(
 }
 \references{
 For more, see:
-\url{https://indrajeetpatil.github.io/ggstatsplot/articles/web_only/pairwise.html}
+\url{https://www.indrapatil.com/ggstatsplot/articles/web_only/pairwise.html}
 }

--- a/man/rmd-fragments/return.Rmd
+++ b/man/rmd-fragments/return.Rmd
@@ -30,4 +30,4 @@ The returned tibble data frame can contain some or all of the following columns 
   
   - `expression`: pre-formatted expression containing statistical details
 
-For examples, see [data frame output vignette](https://indrajeetpatil.github.io/statsExpressions/articles/web_only/dataframe_outputs.html).
+For examples, see [data frame output vignette](https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html).

--- a/man/rmd-fragments/statsExpressions-package.Rmd
+++ b/man/rmd-fragments/statsExpressions-package.Rmd
@@ -19,6 +19,6 @@ This is where `{statsExpressions}` comes in: It can be thought of as a unified
 portal through which most of the functionality in these underlying packages can
 be accessed, with a simpler interface and no requirement to change data format.
 
-This package forms the statistical processing backend for [`ggstatsplot`](https://indrajeetpatil.github.io/ggstatsplot/) package.
+This package forms the statistical processing backend for [`ggstatsplot`](https://www.indrapatil.com/ggstatsplot/) package.
 
-For more documentation, see the dedicated [website](https://indrajeetpatil.github.io/statsExpressions/).
+For more documentation, see the dedicated [website](https://www.indrapatil.com/statsExpressions/).

--- a/man/statsExpressions-package.Rd
+++ b/man/statsExpressions-package.Rd
@@ -28,9 +28,9 @@ This is where \code{{statsExpressions}} comes in: It can be thought of as a unif
 portal through which most of the functionality in these underlying packages can
 be accessed, with a simpler interface and no requirement to change data format.
 
-This package forms the statistical processing backend for \href{https://indrajeetpatil.github.io/ggstatsplot/}{\code{ggstatsplot}} package.
+This package forms the statistical processing backend for \href{https://www.indrapatil.com/ggstatsplot/}{\code{ggstatsplot}} package.
 
-For more documentation, see the dedicated \href{https://indrajeetpatil.github.io/statsExpressions/}{website}.
+For more documentation, see the dedicated \href{https://www.indrapatil.com/statsExpressions/}{website}.
 }
 \details{
 \code{statsExpressions}
@@ -38,7 +38,7 @@ For more documentation, see the dedicated \href{https://indrajeetpatil.github.io
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://indrajeetpatil.github.io/statsExpressions/}
+  \item \url{https://www.indrapatil.com/statsExpressions/}
   \item \url{https://github.com/IndrajeetPatil/statsExpressions}
   \item Report bugs at \url{https://github.com/IndrajeetPatil/statsExpressions/issues}
 }

--- a/man/two_sample_test.Rd
+++ b/man/two_sample_test.Rd
@@ -123,7 +123,7 @@ two degrees of freedom (e.g. anova)
 \item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://indrajeetpatil.github.io/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric, non-parametric, robust, and Bayesian two-sample tests.

--- a/paper/JOSS files/paper.Rmd
+++ b/paper/JOSS files/paper.Rmd
@@ -114,7 +114,7 @@ Function | Parametric | Non-parametric | Robust | Bayesian
 
 : A summary table listing the primary functions in the package and the
 statistical approaches they support. More detailed description of the
-tests and outputs from these functions can be found on the package website: <https://indrajeetpatil.github.io/statsExpressions/articles/>.
+tests and outputs from these functions can be found on the package website: <https://www.indrapatil.com/statsExpressions/articles/>.
 
 `{statsExpressions}` internally relies on `stats` package for parametric and
 non-parametric [@base2021], `WRS2` package for robust [@Mair2020], and

--- a/paper/JOSS files/paper.md
+++ b/paper/JOSS files/paper.md
@@ -73,7 +73,7 @@ utilized downstream in the workflow (such as visualization).
 
 : A summary table listing the primary functions in the package and the
 statistical approaches they support. More detailed description of the
-tests and outputs from these functions can be found on the package website: <https://indrajeetpatil.github.io/statsExpressions/articles/>.
+tests and outputs from these functions can be found on the package website: <https://www.indrapatil.com/statsExpressions/articles/>.
 
 `{statsExpressions}` internally relies on `stats` package for parametric and
 non-parametric [@base2021], `WRS2` package for robust [@Mair2020], and

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,8 +1,8 @@
-url: https://indrajeetpatil.github.io/statsExpressions/
+url: https://www.indrapatil.com/statsExpressions/
 
 authors:
   Indrajeet Patil:
-    href: https://indrajeetpatil.github.io/
+    href: https://www.indrapatil.com/
 
 template:
   bootstrap: 5

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -9,7 +9,7 @@ template:
   light-switch: true
   # includes:
   #   in_header: |
-  #     <script defer data-domain="indrajeetpatil.github.io/statsexpressions" src="https://plausible.io/js/plausible.js"></script>
+  #     <script defer data-domain="www.indrapatil.com/statsexpressions" src="https://plausible.io/js/plausible.js"></script>
   bslib:
     base_font: { google: "Roboto" }
     heading_font: { google: "Roboto" }

--- a/vignettes/statsExpressions.Rmd
+++ b/vignettes/statsExpressions.Rmd
@@ -97,7 +97,7 @@ utilized downstream in the workflow (such as visualization).
 
 : A summary table listing the primary functions in the package and the
 statistical approaches they support. More detailed description of the
-tests and outputs from these functions can be found on the package website: <https://indrajeetpatil.github.io/statsExpressions/articles/>.
+tests and outputs from these functions can be found on the package website: <https://www.indrapatil.com/statsExpressions/articles/>.
 
 `{statsExpressions}` internally relies on `{stats}` package for parametric and
 non-parametric [@base2021], `{WRS2}` package for robust [@Mair2020], and


### PR DESCRIPTION
## Summary

This PR updates all references from the old GitHub Pages domain to the new custom domain:

- **Old**: `https://indrajeetpatil.github.io/`
- **New**: `https://www.indrapatil.com/`

This is part of a bulk domain migration across all repositories.