### PR TITLE
ci: remove redundant 'threshold' input

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -9,5 +9,3 @@ name: test-coverage
 jobs:
   test-coverage:
     uses: IndrajeetPatil/workflows/.github/workflows/test-coverage.yaml@main
-    with:
-      threshold: 100


### PR DESCRIPTION
Removes the redundant 'threshold' input for the test-coverage workflow. Also, the linting process has been simplified upstream in the workflows repository by removing the redundant 'lint-changed-files' job.