### PR TITLE
docs: add examples for t-test annotation and custom workflow

### DIFF
--- a/vignettes/statsExpressions.Rmd
+++ b/vignettes/statsExpressions.Rmd
@@ -137,6 +137,36 @@ mtcars %>%
   ungroup()
 ```
 
+## Custom Statistical Workflows
+
+You can also programmatically aggregate results across different tests, apply automatic *p*-value adjustment across these multiple comparisons, and generate a single formatted expression summarizing all the results together.
+
+```{r}
+#| label = "custom_workflow"
+# chaining multiple test types sequentially and aggregating results
+multi_test_results <- dplyr::bind_rows(
+  two_sample_test(mtcars, am, wt, type = "parametric") %>% mutate(test_type = "Parametric"),
+  two_sample_test(mtcars, am, wt, type = "nonparametric") %>% mutate(test_type = "Nonparametric"),
+  two_sample_test(mtcars, am, wt, type = "robust") %>% mutate(test_type = "Robust")
+) %>%
+  # automatic p-value adjustment across comparisons
+  dplyr::mutate(p.value = stats::p.adjust(p.value, method = "holm"))
+
+# creating a custom formatted expression that summarizes all results together
+summary_expression <- paste(
+  sprintf(
+    "%s: p_adj = %.3f, %s = %.2f",
+    multi_test_results$test_type,
+    multi_test_results$p.value,
+    multi_test_results$effectsize,
+    multi_test_results$estimate
+  ),
+  collapse = "\n"
+)
+
+cat(summary_expression)
+```
+
 ## Expressions for Plots
 
 In addition to other details contained in the data frame, there is also a column
@@ -153,7 +183,7 @@ statistical reporting for both Bayesian [@van2020jasp] and Frequentist
 knitr::include_graphics("stats_reporting_format.png")
 ```
 
-This expression be easily displayed in a plot (Figure 2). Displaying statistical
+This expression can be easily displayed in a plot (Figure 2). Displaying statistical
 results in the context of a visualization is indeed a philosophy adopted by the
 `{ggstatsplot}` package [@Patil2021], and `{statsExpressions}` functions as its
 statistical processing backend.
@@ -167,8 +197,21 @@ statistical processing backend.
 # needed libraries
 library(ggplot2)
 
-# creating a data frame
-res <- oneway_anova(iris, Species, Sepal.Length, type = "nonparametric")
+# Example 1: Performing a t-test on raw tidy data and extracting the formatted expression
+# for direct use in a plot annotation
+res_ttest <- two_sample_test(mtcars, am, wt, type = "parametric")
+
+ggplot(mtcars, aes(as.factor(am), wt)) +
+  geom_boxplot() +
+  labs(
+    x = "Transmission (0 = automatic, 1 = manual)",
+    y = "Weight (1000 lbs)",
+    title = "Vehicle Weight by Transmission Type",
+    subtitle = res_ttest$expression[[1]] # Extract formatted p-value and effect size
+  )
+
+# Example 2: One-way ANOVA
+res_anova <- oneway_anova(iris, Species, Sepal.Length, type = "nonparametric")
 
 ggplot(iris, aes(x = Sepal.Length, y = Species)) +
   geom_boxplot() + # use 'expression' column to display results in the subtitle
@@ -176,7 +219,7 @@ ggplot(iris, aes(x = Sepal.Length, y = Species)) +
     x = "Penguin Species",
     y = "Body mass (in grams)",
     title = "Kruskal-Wallis Rank Sum Test",
-    subtitle = res$expression[[1]]
+    subtitle = res_anova$expression[[1]]
   )
 ```
 


### PR DESCRIPTION
This PR adds documentation examples for performing a t-test and extracting plot annotations, as well as chaining multiple tests into a custom statistical workflow.