### PR TITLE
feat: add exact parameter for non-parametric tests

### DIFF
--- a/API
+++ b/API
@@ -9,14 +9,14 @@ corr_test(data, x, y, type = "parametric", digits = 2L, conf.level = 0.95, tr = 
 extract_stats_type(type)
 long_to_wide_converter(data, x, y, subject.id = NULL, paired = TRUE, spread = TRUE, ...)
 meta_analysis(data, type = "parametric", random = "mixture", digits = 2L, conf.level = 0.95, ...)
-one_sample_test(data, x, type = "parametric", test.value = 0, alternative = "two.sided", digits = 2L, conf.level = 0.95, tr = 0.2, bf.prior = 0.707, effsize.type = "g", ...)
+one_sample_test(data, x, type = "parametric", test.value = 0, alternative = "two.sided", digits = 2L, conf.level = 0.95, tr = 0.2, bf.prior = 0.707, effsize.type = "g", exact = FALSE, ...)
 oneway_anova(data, x, y, subject.id = NULL, type = "parametric", paired = FALSE, digits = 2L, conf.level = 0.95, effsize.type = "omega", var.equal = FALSE, bf.prior = 0.707, tr = 0.2, nboot = 100L, ...)
 p_adjust_text(p.adjust.method)
-pairwise_comparisons(data, x, y, subject.id = NULL, type = "parametric", paired = FALSE, var.equal = FALSE, tr = 0.2, bf.prior = 0.707, p.adjust.method = "holm", digits = 2L, ...)
+pairwise_comparisons(data, x, y, subject.id = NULL, type = "parametric", paired = FALSE, var.equal = FALSE, tr = 0.2, bf.prior = 0.707, p.adjust.method = "holm", digits = 2L, exact = FALSE, ...)
 stats_type_switch(type)
 tidy_model_expressions(data, statistic = NULL, digits = 2L, effsize.type = "omega", ...)
 tidy_model_parameters(model, ...)
-two_sample_test(data, x, y, subject.id = NULL, type = "parametric", paired = FALSE, alternative = "two.sided", digits = 2L, conf.level = 0.95, effsize.type = "g", var.equal = FALSE, bf.prior = 0.707, tr = 0.2, nboot = 100L, ...)
+two_sample_test(data, x, y, subject.id = NULL, type = "parametric", paired = FALSE, alternative = "two.sided", digits = 2L, conf.level = 0.95, effsize.type = "g", var.equal = FALSE, bf.prior = 0.707, tr = 0.2, nboot = 100L, exact = FALSE, ...)
 
 ## Foreign S3 methods
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # statsExpressions (development version)
 
+- Added `exact` parameter to allow users to specify whether an exact *p*-value should be computed for non-parametric tests (#249).
+
 - Fixes a warning emitted when `options(OutDec = ",")` is set (e.g., by users in
   locales that use `,` as the decimal mark) and ensures the generated plotmath
   expressions always use `.` as the decimal mark, since `,` is parsed as a list

--- a/R/one-sample-test.R
+++ b/R/one-sample-test.R
@@ -7,7 +7,7 @@
 #' @param effsize.type Type of effect size needed for *parametric* tests. The
 #'   argument can be `"d"` (for Cohen's *d*) or `"g"` (for Hedge's *g*).
 #' @param exact A logical indicating whether you want exact p-values to be computed.
-#'   Relevant only when `type = "nonparametric"`.
+#'   Relevant only when `type = "nonparametric"` (Default: `FALSE`).
 #' @inheritParams long_to_wide_converter
 #' @inheritParams extract_stats_type
 #' @inheritParams add_expression_col

--- a/R/one-sample-test.R
+++ b/R/one-sample-test.R
@@ -6,6 +6,8 @@
 #'   `0`).
 #' @param effsize.type Type of effect size needed for *parametric* tests. The
 #'   argument can be `"d"` (for Cohen's *d*) or `"g"` (for Hedge's *g*).
+#' @param exact A logical indicating whether you want exact p-values to be computed.
+#'   Relevant only when `type = "nonparametric"`.
 #' @inheritParams long_to_wide_converter
 #' @inheritParams extract_stats_type
 #' @inheritParams add_expression_col
@@ -48,6 +50,7 @@ one_sample_test <- function(
   tr = 0.2,
   bf.prior = 0.707,
   effsize.type = "g",
+  exact = FALSE,
   ...
 ) {
   type <- extract_stats_type(type)
@@ -68,7 +71,7 @@ one_sample_test <- function(
   if (type == "nonparametric") c(.f, .f.es) %<-% c(stats::wilcox.test, effectsize::rank_biserial)
 
   if (type %in% c("parametric", "nonparametric")) {
-    stats_df <- exec(.f, x = x_vec, mu = test.value, alternative = alternative, exact = FALSE) %>%
+    stats_df <- exec(.f, x = x_vec, mu = test.value, alternative = alternative, exact = exact) %>%
       tidy_model_parameters() %>%
       select(-matches("^est|^conf|^diff|^term|^ci"))
 

--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -12,8 +12,6 @@
 #' @param p.adjust.method Adjustment method for *p*-values for multiple
 #'   comparisons. Possible methods are: `"holm"` (default), `"hochberg"`,
 #'   `"hommel"`, `"bonferroni"`, `"BH"`, `"BY"`, `"fdr"`, `"none"`.
-#' @param exact A logical indicating whether you want exact p-values to be computed.
-#'   Relevant only when `type = "nonparametric"`.
 #' @param ... Additional arguments passed to other methods.
 #' @inheritParams stats::t.test
 #' @inheritParams WRS2::rmmcp

--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -9,6 +9,7 @@
 #' @inheritParams long_to_wide_converter
 #' @inheritParams extract_stats_type
 #' @inheritParams oneway_anova
+#' @inheritParams two_sample_test
 #' @param p.adjust.method Adjustment method for *p*-values for multiple
 #'   comparisons. Possible methods are: `"holm"` (default), `"hochberg"`,
 #'   `"hommel"`, `"bonferroni"`, `"BH"`, `"BY"`, `"fdr"`, `"none"`.

--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -12,6 +12,8 @@
 #' @param p.adjust.method Adjustment method for *p*-values for multiple
 #'   comparisons. Possible methods are: `"holm"` (default), `"hochberg"`,
 #'   `"hommel"`, `"bonferroni"`, `"BH"`, `"BY"`, `"fdr"`, `"none"`.
+#' @param exact A logical indicating whether you want exact p-values to be computed.
+#'   Relevant only when `type = "nonparametric"`.
 #' @param ... Additional arguments passed to other methods.
 #' @inheritParams stats::t.test
 #' @inheritParams WRS2::rmmcp
@@ -153,6 +155,7 @@ pairwise_comparisons <- function(
   bf.prior = 0.707,
   p.adjust.method = "holm",
   digits = 2L,
+  exact = FALSE,
   ...
 ) {
   # data -------------------------------------------
@@ -172,7 +175,7 @@ pairwise_comparisons <- function(
   x_vec <- pull(data, {{ x }})
   y_vec <- pull(data, {{ y }})
   g_vec <- pull(data, .rowid)
-  .f.args <- list(paired = paired, p.adjust.method = "none", exact = FALSE, ...)
+  .f.args <- list(paired = paired, p.adjust.method = "none", exact = exact, ...)
 
   # parametric ---------------------------------
 

--- a/R/two-sample-test.R
+++ b/R/two-sample-test.R
@@ -48,6 +48,7 @@ two_sample_test <- function(
   bf.prior = 0.707,
   tr = 0.2,
   nboot = 100L,
+  exact = FALSE,
   ...
 ) {
   # data -------------------------------------------
@@ -80,7 +81,7 @@ two_sample_test <- function(
 
   if (type %in% c("parametric", "nonparametric")) {
     .f.args <- list(x = data[[2L]], y = data[[3L]], paired = paired, alternative = alternative)
-    stats_df <- exec(.f, !!!.f.args, var.equal = var.equal, exact = FALSE) %>% tidy_model_parameters()
+    stats_df <- exec(.f, !!!.f.args, var.equal = var.equal, exact = exact) %>% tidy_model_parameters()
     ez_df <- exec(.f.es, !!!.f.args, pooled_sd = FALSE, ci = conf.level, verbose = FALSE) %>% tidy_model_effectsize()
   }
 

--- a/man/one_sample_test.Rd
+++ b/man/one_sample_test.Rd
@@ -15,6 +15,7 @@ one_sample_test(
   tr = 0.2,
   bf.prior = 0.707,
   effsize.type = "g",
+  exact = FALSE,
   ...
 )
 }
@@ -68,6 +69,9 @@ value corresponds to scale for fixed effects.}
 
 \item{effsize.type}{Type of effect size needed for \emph{parametric} tests. The
 argument can be \code{"d"} (for Cohen's \emph{d}) or \code{"g"} (for Hedge's \emph{g}).}
+
+\item{exact}{A logical indicating whether you want exact p-values to be computed.
+Relevant only when \code{type = "nonparametric"}.}
 
 \item{...}{Currently ignored.}
 }

--- a/man/one_sample_test.Rd
+++ b/man/one_sample_test.Rd
@@ -71,7 +71,7 @@ value corresponds to scale for fixed effects.}
 argument can be \code{"d"} (for Cohen's \emph{d}) or \code{"g"} (for Hedge's \emph{g}).}
 
 \item{exact}{A logical indicating whether you want exact p-values to be computed.
-Relevant only when \code{type = "nonparametric"}.}
+Relevant only when \code{type = "nonparametric"} (Default: \code{FALSE}).}
 
 \item{...}{Currently ignored.}
 }

--- a/man/pairwise_comparisons.Rd
+++ b/man/pairwise_comparisons.Rd
@@ -87,6 +87,9 @@ value as suffix, e.g. \code{digits = "scientific4"} to have scientific
 notation with 4 decimal places, or \code{digits = "signif5"} for 5
 significant figures (see also \code{\link[=signif]{signif()}}).}
 
+\item{exact}{A logical indicating whether you want exact p-values to be computed.
+Relevant only when \code{type = "nonparametric"} (Default: \code{FALSE}).}
+
 \item{...}{Additional arguments passed to other methods.}
 }
 \value{

--- a/man/pairwise_comparisons.Rd
+++ b/man/pairwise_comparisons.Rd
@@ -16,6 +16,7 @@ pairwise_comparisons(
   bf.prior = 0.707,
   p.adjust.method = "holm",
   digits = 2L,
+  exact = FALSE,
   ...
 )
 }
@@ -85,6 +86,9 @@ to return scientific notation. Control the number of digits by adding the
 value as suffix, e.g. \code{digits = "scientific4"} to have scientific
 notation with 4 decimal places, or \code{digits = "signif5"} for 5
 significant figures (see also \code{\link[=signif]{signif()}}).}
+
+\item{exact}{A logical indicating whether you want exact p-values to be computed.
+Relevant only when \code{type = "nonparametric"}.}
 
 \item{...}{Additional arguments passed to other methods.}
 }

--- a/man/pairwise_comparisons.Rd
+++ b/man/pairwise_comparisons.Rd
@@ -87,9 +87,6 @@ value as suffix, e.g. \code{digits = "scientific4"} to have scientific
 notation with 4 decimal places, or \code{digits = "signif5"} for 5
 significant figures (see also \code{\link[=signif]{signif()}}).}
 
-\item{exact}{A logical indicating whether you want exact p-values to be computed.
-Relevant only when \code{type = "nonparametric"}.}
-
 \item{...}{Additional arguments passed to other methods.}
 }
 \value{

--- a/man/two_sample_test.Rd
+++ b/man/two_sample_test.Rd
@@ -102,7 +102,7 @@ of an error, try reducing the value of \code{tr}, which is by default set to
 for the effect size (Default: \code{100L}).}
 
 \item{exact}{A logical indicating whether you want exact p-values to be computed.
-Relevant only when \code{type = "nonparametric"}.}
+Relevant only when \code{type = "nonparametric"} (Default: \code{FALSE}).}
 
 \item{...}{Currently ignored.}
 }

--- a/man/two_sample_test.Rd
+++ b/man/two_sample_test.Rd
@@ -19,6 +19,7 @@ two_sample_test(
   bf.prior = 0.707,
   tr = 0.2,
   nboot = 100L,
+  exact = FALSE,
   ...
 )
 }
@@ -99,6 +100,9 @@ of an error, try reducing the value of \code{tr}, which is by default set to
 
 \item{nboot}{Number of bootstrap samples for computing confidence interval
 for the effect size (Default: \code{100L}).}
+
+\item{exact}{A logical indicating whether you want exact p-values to be computed.
+Relevant only when \code{type = "nonparametric"}.}
 
 \item{...}{Currently ignored.}
 }


### PR DESCRIPTION
Closes https://github.com/IndrajeetPatil/statsExpressions/issues/249. Adds `exact` parameter to `one_sample_test`, `two_sample_test` and `pairwise_comparisons` for nonparametric test options.