### PR TITLE
ci: pass secrets to reusable test-coverage workflow

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -9,3 +9,4 @@ name: test-coverage
 jobs:
   test-coverage:
     uses: IndrajeetPatil/workflows/.github/workflows/test-coverage.yaml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Add `secrets: inherit` so the reusable workflow can access `CODECOV_TOKEN` for authenticated Codecov uploads

Companion to https://github.com/IndrajeetPatil/workflows/pull/20

## Test plan

- [ ] Merge workflows PR first
- [ ] Merge this PR and verify test-coverage workflow passes
- [ ] Confirm coverage appears on Codecov dashboard