### PR TITLE
docs: document data requirements for within-subjects designs

### DIFF
--- a/man/oneway_anova.Rd
+++ b/man/oneway_anova.Rd
@@ -155,6 +155,11 @@ The table below provides summary about:
 
 \subsection{within-subjects}{
 
+\strong{Data requirement}: Repeated measures tests assume a \emph{complete} design with
+exactly \strong{one observation per subject per condition}. If your data has multiple
+trials per cell, aggregate first (e.g., take the mean). Verify with
+\code{table(data$subject, data$condition)} — every cell should equal \code{1}.
+
 \strong{Hypothesis testing}\tabular{llll}{
    Type \tab No. of groups \tab Test \tab Function used \cr
    Parametric \tab > 2 \tab One-way repeated measures ANOVA \tab \code{afex::aov_ez()} \cr

--- a/man/pairwise_comparisons.Rd
+++ b/man/pairwise_comparisons.Rd
@@ -147,6 +147,10 @@ Not supported.
 
 \subsection{within-subjects}{
 
+\strong{Data requirement}: Paired pairwise tests assume exactly \strong{one observation per
+subject per condition}. If your data has multiple trials per cell, aggregate
+first (e.g., take the mean).
+
 \strong{Hypothesis testing}\tabular{llll}{
    Type \tab Test \tab \emph{p}-value adjustment? \tab Function used \cr
    Parametric \tab Student's \emph{t}-test \tab Yes \tab \code{stats::pairwise.t.test()} \cr

--- a/man/rmd-fragments/oneway_anova.Rmd
+++ b/man/rmd-fragments/oneway_anova.Rmd
@@ -20,6 +20,11 @@
 
 #### within-subjects
 
+**Data requirement**: Repeated measures tests assume a *complete* design with
+exactly **one observation per subject per condition**. If your data has multiple
+trials per cell, aggregate first (e.g., take the mean). Verify with
+`table(data$subject, data$condition)` — every cell should equal `1`.
+
 **Hypothesis testing**
 
 | Type           | No. of groups | Test                                                              | Function used            |

--- a/man/rmd-fragments/pairwise_comparisons.Rmd
+++ b/man/rmd-fragments/pairwise_comparisons.Rmd
@@ -16,6 +16,10 @@ Not supported.
 
 #### within-subjects
 
+**Data requirement**: Paired pairwise tests assume exactly **one observation per
+subject per condition**. If your data has multiple trials per cell, aggregate
+first (e.g., take the mean).
+
 **Hypothesis testing**
 
 | Type           | Test                      | *p*-value adjustment? | Function used                     |

--- a/man/rmd-fragments/two_sample_test.Rmd
+++ b/man/rmd-fragments/two_sample_test.Rmd
@@ -20,6 +20,10 @@
 
 #### within-subjects
 
+**Data requirement**: Paired tests assume exactly **one observation per subject
+per condition**. If your data has multiple trials per cell, aggregate first
+(e.g., take the mean).
+
 **Hypothesis testing**
 
 | Type           | No. of groups | Test                                               | Function used            |

--- a/man/two_sample_test.Rd
+++ b/man/two_sample_test.Rd
@@ -164,6 +164,10 @@ The table below provides summary about:
 
 \subsection{within-subjects}{
 
+\strong{Data requirement}: Paired tests assume exactly \strong{one observation per subject
+per condition}. If your data has multiple trials per cell, aggregate first
+(e.g., take the mean).
+
 \strong{Hypothesis testing}\tabular{llll}{
    Type \tab No. of groups \tab Test \tab Function used \cr
    Parametric \tab 2 \tab Student's \emph{t}-test \tab \code{stats::t.test()} \cr

--- a/vignettes/stats_details.Rmd
+++ b/vignettes/stats_details.Rmd
@@ -50,9 +50,10 @@ A few additional requirements are worth noting:
   should equal `1`.
 
 - **`subject.id` argument**: For within-subjects designs, always specify
-  `subject.id` explicitly. If omitted, the function assumes the data is
-  pre-sorted by subject, which can produce incorrect results when `NA`s are
-  present or when there are more than two conditions.
+  `subject.id` explicitly. If omitted, the function pairs observations by
+  row order within each condition, so any data that is not already sorted
+  identically within every condition level can produce silently incorrect
+  paired tests — even with exactly two conditions and no missing values.
 
 - **Missing data**: Missing values are handled internally by removing any subject
   who has `NA` in *any* condition, ensuring a balanced design is maintained.

--- a/vignettes/stats_details.Rmd
+++ b/vignettes/stats_details.Rmd
@@ -37,6 +37,26 @@ more about how one-way (between-subjects) ANOVA, you can run
 
 Abbreviations used: CI = Confidence Interval
 
+## Data requirements
+
+All functions expect data in **long (tidy) format** — one row per observation.
+A few additional requirements are worth noting:
+
+- **Within-subjects (repeated measures) designs**: The data must contain exactly
+  *one* observation per subject per condition (a complete, balanced block design).
+  If you have multiple trials per subject-condition cell, aggregate them first
+  (e.g., by taking the mean) before passing the data.
+  You can verify this with `table(data$subject, data$condition)` — every cell
+  should equal `1`.
+
+- **`subject.id` argument**: For within-subjects designs, always specify
+  `subject.id` explicitly. If omitted, the function assumes the data is
+  pre-sorted by subject, which can produce incorrect results when `NA`s are
+  present or when there are more than two conditions.
+
+- **Missing data**: Missing values are handled internally by removing any subject
+  who has `NA` in *any* condition, ensuring a balanced design is maintained.
+
 ## Summary of functionality
 
 ```{r child="../man/rmd-fragments/functionality.Rmd"}


### PR DESCRIPTION
## Summary

- Adds **"Data requirement"** notes to the within-subjects sections of `oneway_anova`, `two_sample_test`, and `pairwise_comparisons` rmd-fragments, which surface in both `?function` help pages and the `stats_details` vignette
- Adds a **"Data requirements"** section to `stats_details.Rmd` covering the balanced design requirement, `subject.id` usage, and NA handling
- Addresses IndrajeetPatil/ggstatsplot#1088 — users get cryptic errors when repeated-measures data has multiple observations per subject-condition cell

Since `{ggstatsplot}` links to `{statsExpressions}` documentation for statistical details, these notes automatically surface for `{ggstatsplot}` users as well.

## Test plan

- [x] `devtools::document()` regenerates Rd files cleanly
- [x] `devtools::build_vignettes()` succeeds
- [x] `R CMD check` passes with 0 errors, 0 warnings