### PR TITLE
chore: delegate seo-files workflow to shared workflows repo

### DIFF
--- a/.github/workflows/seo-files.yaml
+++ b/.github/workflows/seo-files.yaml
@@ -9,63 +9,8 @@ name: Deploy SEO and agentic discovery files
 jobs:
   deploy-seo-files:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    uses: IndrajeetPatil/workflows/.github/workflows/seo-files.yaml@main
+    with:
+      package-name: "statsExpressions"
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-
-      - name: Create robots.txt
-        run: |
-          cat > robots.txt << 'EOF'
-          User-agent: *
-          Allow: /
-
-          # Explicitly allow AI crawlers for GEO and agentic access
-          User-agent: GPTBot
-          Allow: /
-
-          User-agent: OAI-SearchBot
-          Allow: /
-
-          User-agent: ChatGPT-User
-          Allow: /
-
-          User-agent: ClaudeBot
-          Allow: /
-
-          User-agent: Claude-SearchBot
-          Allow: /
-
-          User-agent: anthropic-ai
-          Allow: /
-
-          User-agent: PerplexityBot
-          Allow: /
-
-          User-agent: Google-Extended
-          Allow: /
-
-          Sitemap: https://www.indrapatil.com/statsExpressions/sitemap.xml
-          EOF
-
-      - name: Create .well-known/llms.txt
-        run: |
-          mkdir -p .well-known
-          cat > .well-known/llms.txt << 'EOF'
-          # LLM Documentation Index for statsExpressions
-          # Machine-readable package documentation for AI assistants
-          # See https://llmstxt.org/ for the specification
-
-          /statsExpressions/llms.txt: Concise package overview optimised for AI assistants
-          EOF
-
-      - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add robots.txt .well-known/
-          git diff --staged --quiet || git commit -m "chore: update SEO and agentic discovery files"
-          git push


### PR DESCRIPTION
## Summary

Replaces the local `seo-files.yaml` (71 lines) with a thin 14-line caller that delegates to [`IndrajeetPatil/workflows`](https://github.com/IndrajeetPatil/workflows).

Changes:
- `actions/checkout@v4` → pinned SHA via shared workflow (v6.0.2)
- `llms-full.txt` entry added (was missing from the local workflow)
- Input passed via env var in shared workflow to avoid code injection (CodeQL)

## Test plan

- [ ] `seo-files.yaml` is ≤ 15 lines and calls `IndrajeetPatil/workflows/.github/workflows/seo-files.yaml@main`
- [ ] `package-name: "statsExpressions"` is set