### PR TITLE
Update package dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,21 +25,21 @@ Depends:
 Imports:
     afex (>= 1.5-1),
     BayesFactor (>= 0.9.12-4.8),
-    bayestestR (>= 0.17.0),
+    bayestestR (>= 0.18.1),
     correlation (>= 0.8.8),
     datawizard (>= 1.3.1),
     dplyr (>= 1.2.1),
-    effectsize (>= 1.0.2),
+    effectsize (>= 1.0.3),
     glue (>= 1.8.1),
-    insight (>= 1.5.0),
-    parameters (>= 0.28.3),
-    performance (>= 0.16.0),
+    insight (>= 1.5.2),
+    parameters (>= 0.29.2),
+    performance (>= 0.17.1),
     PMCMRplus (>= 1.9.12),
     purrr (>= 1.2.2),
-    rlang (>= 1.2.0),
+    rlang (>= 1.3.0),
     rstantools (>= 2.6.0),
     tidyr (>= 1.3.2),
-    withr (>= 3.0.2),
+    withr (>= 3.0.3),
     WRS2 (>= 1.1-7)
 Suggests:
     ggplot2,
@@ -55,6 +55,7 @@ Suggests:
 VignetteBuilder:
     knitr
 Config/Needs/check: anthonynorth/roxyglobals
+Config/roxygen2/version: 8.0.0
 Config/roxyglobals/unique: TRUE
 Config/testthat/edition: 3
 Config/testthat/parallel: true
@@ -63,4 +64,3 @@ Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE, roclets = c("collate", "namespace", "rd",
     "pkgapi::api_roclet", "roxyglobals::global_roclet"))
-Config/roxygen2/version: 8.0.0

--- a/codemeta.json
+++ b/codemeta.json
@@ -207,7 +207,7 @@
       "@type": "SoftwareApplication",
       "identifier": "bayestestR",
       "name": "bayestestR",
-      "version": ">= 0.17.0",
+      "version": ">= 0.18.1",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -259,7 +259,7 @@
       "@type": "SoftwareApplication",
       "identifier": "effectsize",
       "name": "effectsize",
-      "version": ">= 1.0.2",
+      "version": ">= 1.0.3",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -285,7 +285,7 @@
       "@type": "SoftwareApplication",
       "identifier": "insight",
       "name": "insight",
-      "version": ">= 1.5.0",
+      "version": ">= 1.5.2",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -298,7 +298,7 @@
       "@type": "SoftwareApplication",
       "identifier": "parameters",
       "name": "parameters",
-      "version": ">= 0.28.3",
+      "version": ">= 0.29.2",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -311,7 +311,7 @@
       "@type": "SoftwareApplication",
       "identifier": "performance",
       "name": "performance",
-      "version": ">= 0.16.0",
+      "version": ">= 0.17.1",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -350,7 +350,7 @@
       "@type": "SoftwareApplication",
       "identifier": "rlang",
       "name": "rlang",
-      "version": ">= 1.2.0",
+      "version": ">= 1.3.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -389,7 +389,7 @@
       "@type": "SoftwareApplication",
       "identifier": "withr",
       "name": "withr",
-      "version": ">= 3.0.2",
+      "version": ">= 3.0.3",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -413,7 +413,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "4221.181KB",
+  "fileSize": "4221.349KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",

--- a/tests/testthat/_snaps/r-4.7/two-sample-nonparametric.md
+++ b/tests/testthat/_snaps/r-4.7/two-sample-nonparametric.md
@@ -1,0 +1,24 @@
+# nonparametric works - within-subjects design
+
+    Code
+      select(df, -expression)
+    Output
+      # A tibble: 1 x 13
+        parameter1 parameter2 statistic  p.value method                    alternative
+        <chr>      <chr>          <dbl>    <dbl> <chr>                     <chr>      
+      1 desire     condition       2846 0.000213 Wilcoxon signed rank test two.sided  
+        effectsize        estimate conf.level conf.low conf.high conf.method n.obs
+        <chr>                <dbl>      <dbl>    <dbl>     <dbl> <chr>       <int>
+      1 r (rank biserial)    0.487       0.99    0.215     0.690 normal         90
+
+---
+
+    Code
+      df[["expression"]]
+    Output
+      [[1]]
+      list(italic("V")["Wilcoxon"] == "2846.00000", italic(p) == "0.00021", 
+          widehat(italic("r"))["biserial"]^"rank" == "0.48737", CI["99%"] ~ 
+              "[" * "0.21481", "0.68950" * "]", italic("n")["pairs"] == 
+              "90")
+      

--- a/tests/testthat/test-long-to-wide-converter.R
+++ b/tests/testthat/test-long-to-wide-converter.R
@@ -113,7 +113,7 @@ test_that(desc = "with .rowid - without NA", code = {
       score = c(90, 90, 72.5, 45),
       condition = structure(
         c(1L, 2L, 2L, 1L),
-        .Label = c("4", "5"),
+        levels = c("4", "5"),
         class = "factor"
       ),
       id = c(1L, 2L, 1L, 2L)

--- a/tests/testthat/test-two-sample-nonparametric.R
+++ b/tests/testthat/test-two-sample-nonparametric.R
@@ -31,8 +31,9 @@ test_that(desc = "nonparametric works - within-subjects design", code = {
   ))
 
   set.seed(123)
-  expect_snapshot(select(df, -expression))
-  expect_snapshot(df[["expression"]])
+  snapshot_variant <- if (getRversion() >= "4.7.0") "r-4.7" else NULL
+  expect_snapshot(select(df, -expression), variant = snapshot_variant)
+  expect_snapshot(df[["expression"]], variant = snapshot_variant)
 })
 
 test_that(desc = "works with subject id", code = {


### PR DESCRIPTION
## Summary

- refresh minimum CRAN dependency versions in `DESCRIPTION`
- synchronize the generated dependency metadata in `codemeta.json`
- add an R 4.7 snapshot variant for the updated paired Wilcoxon semantics
- replace a deprecated factor `.Label` attribute exposed by R 4.7 checks
- retain the existing roxygen2 8.0.0 configuration in tidy DESCRIPTION order

## Dependency updates

- `bayestestR`: 0.17.0 -> 0.18.1
- `effectsize`: 1.0.2 -> 1.0.3
- `insight`: 1.5.0 -> 1.5.2
- `parameters`: 0.28.3 -> 0.29.2
- `performance`: 0.16.0 -> 0.17.1
- `rlang`: 1.2.0 -> 1.3.0
- `withr`: 3.0.2 -> 3.0.3

## Impact

The package now declares the current CRAN versions used to regenerate and validate the package metadata. R 4.7 changed the handling of zero differences in paired Wilcoxon tests, so the test suite now keeps exact snapshots for both the legacy and R 4.7 outputs without overriding the base-R statistical behavior. Test factor fixtures also use the current `levels` attribute instead of the deprecated `.Label` alias.

## Validation

- `R CMD build .`
- `R CMD check --no-manual statsExpressions_2.0.0.tar.gz` (`Status: OK`)
- `testthat::test_local(filter = "two-sample-nonparametric")`
- `testthat::test_local(filter = "long-to-wide-converter")`
- `make lint`
- `make hooks`
- `git diff --check`
- GitHub Actions R-devel matrix for the R 4.7 compatibility changes
