### PR TITLE
Fix lint workflow and update dependencies

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,3 +9,7 @@ name: R-CMD-check
 jobs:
   R-CMD-check:
     uses: IndrajeetPatil/workflows/.github/workflows/R-CMD-check.yaml@main
+    with:
+      extra-packages: |
+        Deriv@4.2.0
+        RfastOfficial/Rfast

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -11,5 +11,4 @@ jobs:
     uses: IndrajeetPatil/workflows/.github/workflows/R-CMD-check.yaml@main
     with:
       extra-packages: |
-        Deriv@4.2.0
         RfastOfficial/Rfast

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,8 @@ dependency set.
 - Development versions use a fourth-component `.9000` suffix.
 - Keep the version in `DESCRIPTION`, `codemeta.json`, and the first `NEWS.md`
   heading synchronized.
-- Record dependency, compatibility, and CI maintenance changes in `NEWS.md`.
+- Record user-facing compatibility changes in `NEWS.md`; omit routine
+  dependency updates and internal lint or CI maintenance.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,3 +166,7 @@ workflows into this repository.
 
 The shared R CMD check matrix intentionally covers R-devel, release, and
 oldrel. Do not reintroduce `oldrel-2` unless the package support policy changes.
+
+Open pull requests as ready for review rather than as drafts. Unless explicitly
+requested, do not wait for CI/CD checks to finish after pushing; report that the
+checks were triggered and include the pull request or workflow link.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,10 @@ Core dependencies include the tidyverse stack (`dplyr`, `purrr`, `tidyr`, and
 `effectsize`, `bayestestR`, `datawizard`, and `correlation`). Treat
 `DESCRIPTION` as the source of truth for dependency constraints.
 
+The minimum supported R version is 4.5. CI covers R-devel, the current R
+release, and the previous R release; keep README support wording independent of
+specific version numbers.
+
 ## Developer workflow
 
 Use the repository `Makefile` for routine package tasks:
@@ -62,6 +66,13 @@ make update_deps  # Refresh dependency constraints, docs, and codemeta
 `make update_deps` is a maintenance operation that can rewrite dependency
 constraints and generated metadata. Do not use it merely to install the current
 dependency set.
+
+### Versioning and changelog
+
+- Development versions use a fourth-component `.9000` suffix.
+- Keep the version in `DESCRIPTION`, `codemeta.json`, and the first `NEWS.md`
+  heading synchronized.
+- Record dependency, compatibility, and CI maintenance changes in `NEWS.md`.
 
 ## Testing
 
@@ -151,3 +162,6 @@ coverage, documentation and extra checks, formatting, linting, prek hooks,
 pkgdown builds, and deployment tasks. Most jobs call reusable workflows from
 `IndrajeetPatil/workflows`; update the callers rather than copying those
 workflows into this repository.
+
+The shared R CMD check matrix intentionally covers R-devel, release, and
+oldrel. Do not reintroduce `oldrel-2` unless the package support policy changes.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,7 @@ Suggests:
 VignetteBuilder:
     knitr
 Config/Needs/check: anthonynorth/roxyglobals
+Config/Needs/coverage: RfastOfficial/Rfast
 Config/Needs/website: RfastOfficial/Rfast
 Config/roxygen2/version: 8.0.0
 Config/roxyglobals/unique: TRUE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,7 @@ Suggests:
 VignetteBuilder:
     knitr
 Config/Needs/check: anthonynorth/roxyglobals
+Config/Needs/website: RfastOfficial/Rfast
 Config/roxygen2/version: 8.0.0
 Config/roxyglobals/unique: TRUE
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ URL: https://www.indrapatil.com/statsExpressions/,
     https://github.com/IndrajeetPatil/statsExpressions
 BugReports: https://github.com/IndrajeetPatil/statsExpressions/issues
 Depends:
-    R (>= 4.3.0),
+    R (>= 4.5.0),
     stats
 Imports:
     afex (>= 1.5-1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: statsExpressions
 Title: Tidy Dataframes and Expressions with Statistical Details
-Version: 2.0.0
+Version: 2.0.0.9000
 Authors@R:
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = c("cre", "aut", "cph"),
            comment = c(ORCID = "0000-0003-1995-6531"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     PMCMRplus (>= 1.9.12),
     purrr (>= 1.2.2),
     rlang (>= 1.3.0),
-    rstantools (>= 2.6.0),
+    rstantools (>= 2.7.0),
     tidyr (>= 1.3.2),
     withr (>= 3.0.3),
     WRS2 (>= 1.1-7)

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,14 +3,6 @@
 - The minimum supported R version is now 4.5. The project supports R-devel,
   the current R release, and the previous R release.
 
-- Dependency requirements have been refreshed, including `rstantools >= 2.7.0`.
-
-- Internal tests now use dedicated shape expectations to comply with current
-  `{lintr}` rules.
-
-- CI now rebuilds `{Rfast}` against the active `{RcppParallel}` TBB ABI,
-  including for example and vignette coverage.
-
 # statsExpressions 2.0.0
 
 This major release accompanies the upcoming stable 1.0.0 release of

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# statsExpressions 2.0.0.9000
+
+- The minimum supported R version is now 4.5. The project supports R-devel,
+  the current R release, and the previous R release.
+
+- Dependency requirements have been refreshed, including `rstantools >= 2.7.0`.
+
+- Internal tests now use dedicated shape expectations to comply with current
+  `{lintr}` rules.
+
+- CI now rebuilds `{Rfast}` against the active `{RcppParallel}` TBB ABI,
+  including for example and vignette coverage.
+
 # statsExpressions 2.0.0
 
 This major release accompanies the upcoming stable 1.0.0 release of

--- a/README.Rmd
+++ b/README.Rmd
@@ -29,6 +29,9 @@ Status | Usage | Miscellaneous
 [![R build status](https://github.com/IndrajeetPatil/statsExpressions/workflows/R-CMD-check/badge.svg)](https://github.com/IndrajeetPatil/statsExpressions/actions) | [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/statsExpressions?color=blue)](https://CRAN.R-project.org/package=statsExpressions) | [![Codecov](https://codecov.io/gh/IndrajeetPatil/statsExpressions/branch/main/graph/badge.svg)](https://app.codecov.io/gh/IndrajeetPatil/statsExpressions?branch=main)
 [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html) | [![Daily downloads](https://cranlogs.r-pkg.org/badges/last-day/statsExpressions?color=blue)](https://CRAN.R-project.org/package=statsExpressions) | [![DOI](https://joss.theoj.org/papers/10.21105/joss.03236/status.svg)](https://doi.org/10.21105/joss.03236)
 
+> [!NOTE]
+> This package supports R-devel, the current R release, and the previous R release.
+
 # Introduction <img src="man/figures/logo.png" alt="statsExpressions package logo" align="right" width="240" />
 
 ```{r, child = "man/rmd-fragments/statsExpressions-package.Rmd"}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 | [![R build status](https://github.com/IndrajeetPatil/statsExpressions/workflows/R-CMD-check/badge.svg)](https://github.com/IndrajeetPatil/statsExpressions/actions) | [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/statsExpressions?color=blue)](https://CRAN.R-project.org/package=statsExpressions) | [![Codecov](https://codecov.io/gh/IndrajeetPatil/statsExpressions/branch/main/graph/badge.svg)](https://app.codecov.io/gh/IndrajeetPatil/statsExpressions?branch=main) |
 | [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html) | [![Daily downloads](https://cranlogs.r-pkg.org/badges/last-day/statsExpressions?color=blue)](https://CRAN.R-project.org/package=statsExpressions) | [![DOI](https://joss.theoj.org/papers/10.21105/joss.03236/status.svg)](https://doi.org/10.21105/joss.03236) |
 
+> [!NOTE]
+> This package supports R-devel, the current R release, and the previous R release.
+
 # Introduction <img src="man/figures/logo.png" alt="statsExpressions package logo" align="right" width="240" />
 
 The `{statsExpressions}` package has two key aims:

--- a/codemeta.json
+++ b/codemeta.json
@@ -363,7 +363,7 @@
       "@type": "SoftwareApplication",
       "identifier": "rstantools",
       "name": "rstantools",
-      "version": ">= 2.6.0",
+      "version": ">= 2.7.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -413,7 +413,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "4221.349KB",
+  "fileSize": "4222.425KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",

--- a/codemeta.json
+++ b/codemeta.json
@@ -170,7 +170,7 @@
       "@type": "SoftwareApplication",
       "identifier": "R",
       "name": "R",
-      "version": ">= 4.3.0"
+      "version": ">= 4.5.0"
     },
     "2": {
       "@type": "SoftwareApplication",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/IndrajeetPatil/statsExpressions",
   "issueTracker": "https://github.com/IndrajeetPatil/statsExpressions/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "2.0.0",
+  "version": "2.0.0.9000",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/tests/testthat/test-long-to-wide-converter.R
+++ b/tests/testthat/test-long-to-wide-converter.R
@@ -193,5 +193,5 @@ test_that("NA in subject.id does not drop rows with complete measurements", {
     spread = FALSE
   )
 
-  expect_identical(nrow(result), 4L)
+  expect_shape(result, nrow = 4L)
 })

--- a/tests/testthat/test-pairwise-contingency-table.R
+++ b/tests/testthat/test-pairwise-contingency-table.R
@@ -13,7 +13,7 @@ test_that("pairwise_contingency_table works - basic", {
   expect_snapshot(df1[["expression"]])
 
   # correct number of pairs (3 levels -> 3 pairs)
-  expect_identical(nrow(df1), 3L)
+  expect_shape(df1, nrow = 3L)
 
   # both raw and adjusted p-values present
   expect_true(all(c("p.value", "p.value.adj") %in% names(df1)))
@@ -38,7 +38,7 @@ test_that("pairwise_contingency_table works - with counts", {
   expect_snapshot(df1[["expression"]])
 
   # 4 levels -> C(4,2) = 6 pairs
-  expect_identical(nrow(df1), 6L)
+  expect_shape(df1, nrow = 6L)
 })
 
 # no adjustment --------------------------------------------------


### PR DESCRIPTION
## Summary

- replace direct row-count assertions with `testthat::expect_shape()` to satisfy the newly enabled `expect_shape_linter`
- raise the minimum `rstantools` version from 2.6.0 to 2.7.0
- raise the minimum supported R version from 4.3.0 to 4.5.0
- add a future-proof README callout for R-devel, the current R release, and the previous R release
- begin the `2.0.0.9000` development cycle in `DESCRIPTION`, `codemeta.json`, and `NEWS.md`
- record the user-facing R compatibility change in `NEWS.md` and update `AGENTS.md` with versioning, R-support, changelog, and PR-handoff guidance
- rebuild `Rfast` from its official source in website, coverage, and package-check CI so it links against the active `RcppParallel`/TBB ABI

## Why

The scheduled lint workflow began failing after the current `lintr` release enabled `expect_shape_linter`; the source commit itself had previously passed. Using the dedicated shape assertion preserves the test intent while complying with the current lint rule.

The supported-version policy now covers R-devel, the current R release, and the previous R release. The reusable workflow no longer runs `oldrel-2` after IndrajeetPatil/workflows#46 was merged, so the R 4.4-only `Deriv 4.2.0` pin has been removed.

The separate `Rfast` source override remains necessary because `RcppParallel 6.2.0` changed the TBB ABI and cached downstream binaries referenced obsolete symbols. Applying it to the coverage dependency set also keeps the conditional `meta_analysis()` examples available and preserves 100% example coverage.

## Validation

- `make update_deps`
- focused tests for `long-to-wide-converter` and `pairwise-contingency-table`
- `make lint`
- `make hooks`
- `make check` under R 4.5.0 for package version `2.0.0.9000` (`R CMD check --no-manual`: Status OK)
- pak dependency resolution selects source `Rfast 2.1.5.2` for check, website, and coverage dependency sets
- `git diff --check`