### PR TITLE
Simplify expression parsing

### DIFF
--- a/R/tidy-model-expressions.R
+++ b/R/tidy-model-expressions.R
@@ -116,14 +116,8 @@ tidy_model_expressions <- function(
 #' @noRd
 .glue_to_expression <- function(data) {
   data |>
-    rowwise() |>
-    mutate(expression = list(parse_expr(expression))) |>
-    ungroup() |> # convert from `expression` to `language`
     mutate(
-      expression = case_when(
-        is.na(unlist(expression)) ~ list(NULL),
-        .default = unlist(expression)
-      )
+      expression = parse_exprs(replace(expression, is.na(expression), "NULL"))
     ) |>
     .add_package_class()
 }


### PR DESCRIPTION
## Summary

- Remove the rowwise parsing, ungrouping, repeated flattening, and missing-value repair pipeline from `.glue_to_expression()`.
- Use vectorized `rlang::parse_exprs()` from the existing required `rlang` dependency, replacing missing expression strings with the literal `NULL` before parsing so the list-column contract remains unchanged.
- Collapse seven lines of custom orchestration into one mutation without adding a dependency or changing package output.

## Why this is simpler

The previous implementation manually adapted scalar `parse_expr()` across grouped rows and then repaired the resulting list column. The current `rlang` API already parses a character vector into a list of expressions, including parsed `NULL` entries. Using that dependency capability removes grouping state and flattening logic that this package no longer needs to own.

No dependency constraint changed: `DESCRIPTION` already requires `rlang (>= 1.3.0)`, and that supported version provides `parse_exprs()`.

## Validation

- Focused expression-producing tests: 120 assertions passed with no failures and no snapshot changes
- `make lint`
- `make hooks`
- `make check` (`Status: OK`)
- `git diff --check`

## Changelog

`NEWS.md` was not updated because this is a minor internal simplification with unchanged behavior and no dependency-version compatibility change.