### PR TITLE
Simplify p-adjustment label formatting

### DIFF
--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -304,7 +304,11 @@ pairwise_comparisons <- function(
   data |>
     mutate(
       p.value.adj = stats::p.adjust(p = p.value, method = p.adjust.method),
-      p.adjust.method = p_adjust_text(p.adjust.method),
+      p.adjust.method = recode(
+        insight::format_capitalize(p.adjust.method),
+        BH = "FDR",
+        Fdr = "FDR"
+      ),
       test = test,
       expression = case_when(
         p.adjust.method == "None" ~ glue(
@@ -315,17 +319,4 @@ pairwise_comparisons <- function(
         )
       )
     )
-}
-
-#' @noRd
-p_adjust_text <- function(p.adjust.method) {
-  case_when(
-    grepl("^n|^bo|^h", p.adjust.method) ~ paste0(
-      toupper(substr(p.adjust.method, 1L, 1L)),
-      substr(p.adjust.method, 2L, nchar(p.adjust.method))
-    ),
-    grepl("^BH|^f", p.adjust.method) ~ "FDR",
-    grepl("^BY", p.adjust.method) ~ "BY",
-    .default = "Holm"
-  )
 }


### PR DESCRIPTION
## Summary

- Remove the bespoke `p_adjust_text()` helper and its regex-driven capitalization branches.
- Use `insight::format_capitalize()` from the existing required dependency, retaining only the two package-specific aliases that normalize `BH` and `fdr` to `FDR`.
- Preserve all existing adjustment labels and plotmath expressions across `pairwise_comparisons()` and `pairwise_contingency_table()`.

## Why this is simpler

The package previously owned general string-capitalization logic for p-value adjustment methods. The current `insight` API already solves that formatting task, so the local implementation is reduced from a standalone helper with multiple branches to a dependency call plus the two aliases that represent actual package policy. This deletes 14 lines, adds 5, and removes one internal function without adding a dependency.

The existing minimum `insight (>= 1.5.2)` already provides `format_capitalize()`, so neither `DESCRIPTION` nor `codemeta.json` needed regeneration.

## Validation

- Focused pairwise tests for both consumers passed with no snapshot changes
- Explicit compatibility check covered `none`, `bonferroni`, `hochberg`, `hommel`, `BH`, `fdr`, `BY`, and `holm`
- `make lint`
- `make hooks`
- `make check` (`Status: OK`)
- `git diff --check`

## Changelog

`NEWS.md` was not updated because this is a minor internal simplification with unchanged behavior and no dependency-version compatibility change.