### PR TITLE
Simplify subject-id assignment with per-operation `.by`

### DIFF
--- a/R/long-to-wide-converter.R
+++ b/R/long-to-wide-converter.R
@@ -74,15 +74,14 @@ long_to_wide_converter <- function(
     arrange({{ x }})
 
   if (!".rowid" %in% names(data)) {
-    if (paired) {
-      data <- group_by(data, {{ x }})
+    data <- if (paired) {
+      mutate(data, .rowid = row_number(), .by = {{ x }})
+    } else {
+      mutate(data, .rowid = row_number())
     }
-    data <- mutate(data, .rowid = row_number())
   }
 
-  data <- data |>
-    ungroup() |>
-    filter(!anyNA(pick({{ x }}, {{ y }})), .by = .rowid)
+  data <- filter(data, !anyNA(pick({{ x }}, {{ y }})), .by = .rowid)
 
   # convert to wide?
   if (spread) {


### PR DESCRIPTION
## Summary

- Replace the `group_by()` → `mutate()` → `ungroup()` scaffolding in `long_to_wide_converter()` with a single per-operation `.by` mutate.
- The function already used `dplyr`'s per-operation `.by` on the very next line (the NA-filter step); this change applies the same idiom to the internal `.rowid` assignment so the whole function relies on one grouping mechanism instead of mixing persistent-grouping state with per-operation grouping.

## Liability removed

The previous implementation created a persistent grouped data frame (`group_by({{ x }})`) purely to number rows within each group, then had to undo that state with a standalone `ungroup()` before the next step. That is stateful indirection: the reader has to track that the frame is grouped across three statements, and the `ungroup()` exists only to clean up. Adopting `mutate(.rowid = row_number(), .by = {{ x }})` scopes the grouping to the single operation that needs it and deletes the cleanup entirely.

## Newer-dependency capability, not a new dependency

This uses `dplyr`'s per-operation `.by` argument. No dependency was added and no minimum version changed: `DESCRIPTION` already requires `dplyr (>= 1.2.1)`, and `.by` has been available since `dplyr` 1.1.0. The same function already depends on `.by` for its NA filter, so this introduces no new capability requirement. Because there is no dependency-version change, `DESCRIPTION` and `codemeta.json` did not need regeneration.

## Code deleted / collapsed

- Removed the `group_by({{ x }})` branch and the standalone `ungroup()` call.
- Net diff: 5 insertions, 6 deletions in a single file.

## Regression safety

- **Byte-for-byte equivalence**: captured `long_to_wide_converter()` output on 7 representative call paths (within/between-subjects, spread on/off, explicit `subject.id`, and NA-containing data) before the change, then confirmed every result was `all.equal()`-identical afterward.
- **Tests** (`NOT_CRAN=true`): the function's own tests pass, and all downstream consumers pass with 0 failures — `two_sample_test`, `oneway_anova` (parametric/nonparametric/robust/bayes), `pairwise_comparisons`, `pairwise_contingency_table`, and one-sample suites. The identity tests that assert the internal-id path matches the explicit-`subject.id` path, and the test guarding that `NA` in `subject.id` does not drop rows with complete measurements, both continue to pass.
- `lintr::lint()`: no lints. `styler`: file unchanged. `prek run --all-files`: passed.

## Changelog

`NEWS.md` was not updated: this is a minor internal simplification with unchanged behavior and no dependency-version compatibility change.