### PR TITLE
Deduplicate degrees-of-freedom expression templates

### DIFF
--- a/R/add-expression-col.R
+++ b/R/add-expression-col.R
@@ -138,50 +138,31 @@ add_expression_col <- function(
       )
   }
 
-  # 0 degrees of freedom --------------------
+  # frequentist analysis (0, 1, or 2 degrees of freedom) --------------------
 
-  if (!bayesian && no.parameters == 0L) {
-    df_expr <- df_expr |>
-      mutate(
-        expression = glue(
-          "list(
-            {statistic.text}=='{statistic}', italic(p)=='{p.value}',
-            {es.text}=='{estimate}', CI['{conf.level}']~'['*'{conf.low}', '{conf.high}'*']',
-            {n.text}=='{n.obs}')"
-        )
-      )
-  }
-
-  # 1 degree of freedom --------------------
-
-  if (!bayesian && no.parameters == 1L) {
-    if ("df" %in% colnames(df_expr)) {
+  if (!bayesian) {
+    # for chi-squared statistic, the degrees of freedom live in the `df` column
+    if (no.parameters == 1L && "df" %in% colnames(df_expr)) {
       df_expr <- mutate(df_expr, df.error = df)
-    } # for chi-squared statistic
+    }
 
-    df_expr <- df_expr |>
-      mutate(
-        expression = glue(
-          "list(
-            {statistic.text}*'('*{df.error}*')'=='{statistic}', italic(p)=='{p.value}',
-            {es.text}=='{estimate}', CI['{conf.level}']~'['*'{conf.low}', '{conf.high}'*']',
-            {n.text}=='{n.obs}')"
-        )
-      )
-  }
+    # the statistic term is the only part that varies with the number of
+    # degrees of freedom; the rest of the expression is shared
+    statistic_part <- switch(
+      as.character(no.parameters),
+      "0" = "{statistic.text}=='{statistic}'",
+      "1" = "{statistic.text}*'('*{df.error}*')'=='{statistic}'",
+      "2" = "{statistic.text}({df}, {df.error})=='{statistic}'"
+    )
 
-  # 2 degrees of freedom -----------------
+    expr_template <- paste0(
+      "list(",
+      statistic_part,
+      ", italic(p)=='{p.value}', {es.text}=='{estimate}', ",
+      "CI['{conf.level}']~'['*'{conf.low}', '{conf.high}'*']', {n.text}=='{n.obs}')"
+    )
 
-  if (!bayesian && no.parameters == 2L) {
-    df_expr <- df_expr |>
-      mutate(
-        expression = glue(
-          "list(
-            {statistic.text}({df}, {df.error})=='{statistic}', italic(p)=='{p.value}',
-            {es.text}=='{estimate}', CI['{conf.level}']~'['*'{conf.low}', '{conf.high}'*']',
-            {n.text}=='{n.obs}')"
-        )
-      )
+    df_expr <- mutate(df_expr, expression = glue(expr_template))
   }
 
   # convert `expression` to `language`


### PR DESCRIPTION
## Summary

- Collapse the three near-identical `glue` templates in `add_expression_col()` — one each for the 0-, 1-, and 2-degrees-of-freedom frequentist cases — into a single shared template whose only varying piece is the statistic term.
- This adopts the exact `stat_part` + `expr_template` idiom already established in `tidy_model_expressions()`, so the package now expresses "build a statistic fragment, then splice it into one shared expression body" in one consistent way.

## Liability removed

The frequentist branch carried three `if (!bayesian && no.parameters == N)` blocks, each with its own multi-line `glue()` string. The tail of all three strings — the `p.value`, effect size, confidence interval, and sample-size terms — was **byte-for-byte identical**; only the leading statistic term differed:

| df | statistic term |
|----|----------------|
| 0  | `{statistic.text}=='{statistic}'` |
| 1  | `{statistic.text}*'('*{df.error}*')'=='{statistic}'` |
| 2  | `{statistic.text}({df}, {df.error})=='{statistic}'` |

Three copies of the same expression body is a maintenance hazard: any tweak to the shared formatting (a new term, a spacing change, a CI-format fix) had to be applied identically in three places or the outputs would silently diverge. Collapsing them to one template removes that duplication.

## Newer-dependency capability, not a new dependency

This is a duplicated-logic reduction, not a dependency change. No dependency was added and no minimum version changed — the consolidated template uses the same `glue` (already a dependency, `>= 1.8.1`) and reuses the `paste0()`-assembled-template + single-`glue()` pattern that `tidy_model_expressions()` already relies on. Because there is no dependency-version change, `DESCRIPTION` and `codemeta.json` did not need regeneration, and `R/globals.R` is unchanged (no new `@autoglobal` symbols).

## Code deleted / collapsed

- Removed three separate `if` blocks (~40 lines) each holding a full multi-line `glue()` string.
- Added one `if (!bayesian)` block (~24 lines): the chi-squared `df -> df.error` fixup, a `switch()` selecting the statistic fragment, one assembled `expr_template`, and a single `glue()` call.
- Net: **+21 / −40** in `R/add-expression-col.R`, single file.

## Regression safety

- **Parsed-expression equivalence**: the expression column holds `language` objects produced by `parse_exprs()`, and snapshots store their deparsed form (whitespace-normalized by R's deparser). The consolidated template emits the same tokens as before, so every parsed expression — and thus every snapshot — is identical. Verified by rendering all three df paths directly (`two_sample_test` → 0 df, `contingency_table` → 1 df, `oneway_anova` → 2 df) and confirming the output matches the pre-change format.
- **Tests** (`NOT_CRAN=true`): ran every suite that exercises `add_expression_col()` — one/two-sample, one-way ANOVA, contingency-table, correlation, centrality, pairwise, and meta-analysis, across parametric / nonparametric / robust / Bayesian paths. All pass with **no failures, no errors, and no snapshot changes**.
- `lintr::lint("R/add-expression-col.R")`: no lints.

## Changelog

`NEWS.md` was **not** updated: this is a minor internal simplification with unchanged behavior and no dependency-version compatibility change, consistent with the recent simplification PRs (#380–#384).