### PR TITLE
Modernize superseded dplyr::recode() usages

### DIFF
--- a/R/add-expression-col.R
+++ b/R/add-expression-col.R
@@ -97,7 +97,7 @@ add_expression_col <- function(
   if (!"effectsize" %in% colnames(data)) {
     data <- mutate(data, effectsize = method)
   }
-  data <- rename_with(data, recode, bayes.factor = "bf10")
+  data <- rename(data, any_of(c(bf10 = "bayes.factor")))
 
   bayesian <- any("bf10" == colnames(data))
   no.parameters <- sum("df.error" %in% names(data) + "df" %in% names(data))

--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -300,14 +300,17 @@ pairwise_comparisons <- function(
 
 #' @noRd
 .pairwise_p_adjust_expr <- function(data, p.adjust.method, digits, test) {
+  method_label <- insight::format_capitalize(p.adjust.method)
+  method_label <- recode_values(
+    method_label,
+    c("BH", "Fdr") ~ "FDR",
+    default = method_label
+  )
+
   data |>
     mutate(
       p.value.adj = stats::p.adjust(p = p.value, method = p.adjust.method),
-      p.adjust.method = recode(
-        insight::format_capitalize(p.adjust.method),
-        BH = "FDR",
-        Fdr = "FDR"
-      ),
+      p.adjust.method = method_label,
       test = test,
       expression = case_when(
         p.adjust.method == "None" ~ glue(


### PR DESCRIPTION
## What liability was removed

Two call sites still relied on `dplyr::recode()`, which dplyr **superseded** and no longer recommends (its current guidance points to `recode_values()`, and `case_match()` is itself now deprecated in favor of `recode_values()`). Continuing to lean on a superseded function is ongoing maintenance risk: it receives no new features and is a candidate for eventual deprecation/removal. The package already adopted `recode_values()` in `centrality_description()`, so these two sites were the last holdouts and were also stylistically inconsistent with the rest of the codebase.

## Source of the simplification

A **newer capability in an already-required dependency** (dplyr ≥ 1.2.1, already declared in `DESCRIPTION`). No new dependency and no version bump — just adopting the current, recommended API and, in one case, a more direct built-in.

## What changed

- **`add_expression_col()`** — the defensive `bayes.factor` → `bf10` rename went from the roundabout `rename_with(data, recode, bayes.factor = "bf10")` (applies `recode()` across *all* column names) to the direct, intent-revealing `rename(data, any_of(c(bf10 = "bayes.factor")))`. `any_of()` preserves the "rename only if present" behavior, so indirection is collapsed with no behavior change.
- **`.pairwise_p_adjust_expr()`** — the p-adjustment label recode moved from `recode(insight::format_capitalize(...), BH = "FDR", Fdr = "FDR")` to `recode_values(..., c("BH", "Fdr") ~ "FDR", default = ...)`, matching the idiom already used in `centrality_description()`. The capitalization is now computed once instead of inline, avoiding a duplicated call.

Net: the last uses of the superseded `dplyr::recode()` are gone; the codebase now uses `recode_values()` consistently.

## How I ensured it stays regression-free

- Confirmed byte-for-byte equivalence of both replacements against the originals in an isolated R session across all relevant inputs (present/absent `bayes.factor` column; every supported `p.adjust.method` incl. `holm`, `BH`, `fdr`, `bonferroni`, `none`).
- Ran the affected test files with `NOT_CRAN=true` — `test-pairwise-comparisons.R`, `test-pairwise-contingency-table.R`, `test-contingency-table.R` — plus the Bayesian/`add_expression_col` paths (`test-two-sample-bayes.R`, `test-one-sample.R`, `test-corr-test.R`): **0 failures, 0 errors, 0 skips**, snapshots unchanged.
- `lintr` reports 0 lints on both changed files.

## NEWS.md

Not updated: this is a routine, behavior-preserving cleanup (not a significant refactoring) and it introduces no dependency or minimum-version change, so per the changelog policy it does not warrant an entry.