### PR TITLE
Deduplicate mean-difference effect-size selector

### DIFF
--- a/R/one-sample-test.R
+++ b/R/one-sample-test.R
@@ -60,13 +60,7 @@ one_sample_test <- function(
 
   if (type == "parametric") {
     .f <- stats::t.test
-    .f.es <- switch(
-      match.arg(effsize.type, c("g", "d", "unbiased", "biased")),
-      g = ,
-      unbiased = effectsize::hedges_g,
-      d = ,
-      biased = effectsize::cohens_d
-    )
+    .f.es <- .mean_difference_effsize(effsize.type)
   }
 
   # non-parametric ---------------------------------------

--- a/R/switch-functions.R
+++ b/R/switch-functions.R
@@ -103,3 +103,18 @@ prior_switch <- function(x) {
 .grepl <- function(pattern, x) grepl(pattern, x, fixed = TRUE)
 
 # styler: on
+
+#' @title Select the parametric effect size for mean-difference tests
+#' @description Maps the user-facing `effsize.type` to the corresponding
+#'   `{effectsize}` function (Hedges' *g* when unbiased, Cohen's *d* when
+#'   biased). Shared by [one_sample_test()] and [two_sample_test()].
+#' @noRd
+.mean_difference_effsize <- function(effsize.type) {
+  switch(
+    match.arg(effsize.type, c("g", "d", "unbiased", "biased")),
+    g = ,
+    unbiased = effectsize::hedges_g,
+    d = ,
+    biased = effectsize::cohens_d
+  )
+}

--- a/R/two-sample-test.R
+++ b/R/two-sample-test.R
@@ -148,13 +148,7 @@ two_sample_test <- function(
   if (type == "parametric") {
     digits.df <- ifelse(paired || var.equal, 0L, digits)
     .f <- stats::t.test
-    .f.es <- switch(
-      match.arg(effsize.type, c("g", "d", "unbiased", "biased")),
-      g = ,
-      unbiased = effectsize::hedges_g,
-      d = ,
-      biased = effectsize::cohens_d
-    )
+    .f.es <- .mean_difference_effsize(effsize.type)
   }
 
   # non-parametric ------------------------------------


### PR DESCRIPTION
## What liability was removed

`one_sample_test()` and `two_sample_test()` each carried an **identical** 7-line block that maps the user-facing `effsize.type` to the corresponding `{effectsize}` function:

```r
.f.es <- switch(
  match.arg(effsize.type, c("g", "d", "unbiased", "biased")),
  g = ,
  unbiased = effectsize::hedges_g,
  d = ,
  biased = effectsize::cohens_d
)
```

Two verbatim copies of the same logic is a maintenance hazard: any change to the supported effect-size aliases (or the mapping) had to be made in two places and kept in sync.

## Source of the simplification

This is a pure **deduplication of the repo's own custom code** — no new dependency and no new dependency capability involved. It continues the recent series of deduplication cleanups (degrees-of-freedom templates, contingency-table counts prep, pairwise result mapping).

## What was collapsed

- Added a single internal `@noRd` helper `.mean_difference_effsize()` in `R/switch-functions.R`, alongside the existing statistics-selector family (`extract_stats_type()`, `extract_estimate_type()`, etc.).
- Replaced both duplicated blocks with a one-line call to the helper.

Net: two 7-line blocks → one shared 7-line helper plus two one-line call sites (**17 insertions, 14 deletions**, and the shared logic now lives in exactly one place).

## How I ensured it stayed regression-free

- Behaviour is identical: the helper contains the exact same `switch(match.arg(...))` expression that was inlined before, so every `effsize.type` alias (`"g"`/`"unbiased"` → Hedges' *g*, `"d"`/`"biased"` → Cohen's *d*) resolves to the same function.
- Ran the affected test suites with `NOT_CRAN=true`, all passing:
  - `test-one-sample.R` — FAIL=0 PASS=32
  - `test-two-sample-parametric.R` — FAIL=0 PASS=9
  - `test-two-sample-nonparametric.R` — FAIL=0 PASS=5
  - `test-two-sample-bayes.R` — FAIL=0 PASS=4
  - `test-two-sample-robust.R` — FAIL=0 PASS=9
  - (The WRS2 `tr`/`trim` partial-match warnings in the robust path are pre-existing and unrelated to this change.)
- `lintr` reports no lints on the three changed files.

## `NEWS.md`

Not updated — this is a routine internal deduplication with no user-facing or behavioural change and no dependency version bump, which per the repo's changelog policy does not warrant a NEWS entry.