### PR TITLE
Deduplicate paired-aware observation count

### DIFF
--- a/R/long-to-wide-converter.R
+++ b/R/long-to-wide-converter.R
@@ -94,3 +94,13 @@ long_to_wide_converter <- function(
 
   as_tibble(relocate(data, .rowid) |> arrange(.rowid))
 }
+
+#' @title Paired-aware observation count for the expression's `n`
+#' @description Returns the number of unique subjects for repeated-measures
+#'   designs (`paired = TRUE`) and the number of rows otherwise, operating on
+#'   the `.rowid`-tagged data frame produced by [long_to_wide_converter()].
+#'   Shared by [two_sample_test()] and [oneway_anova()].
+#' @noRd
+.n_obs <- function(data, paired) {
+  ifelse(paired, length(unique(data$.rowid)), nrow(data))
+}

--- a/R/oneway-anova.R
+++ b/R/oneway-anova.R
@@ -319,7 +319,7 @@ oneway_anova <- function(
 
   add_expression_col(
     data = stats_df,
-    n = ifelse(paired, length(unique(data$.rowid)), nrow(data)),
+    n = .n_obs(data, paired),
     paired = paired,
     digits = digits,
     digits.df = digits.df,

--- a/R/two-sample-test.R
+++ b/R/two-sample-test.R
@@ -249,7 +249,7 @@ two_sample_test <- function(
       .standardize_two_sample_terms(stats_df, as_name(x), as_name(y))
     },
     paired = paired,
-    n = ifelse(paired, length(unique(data$.rowid)), nrow(data)),
+    n = .n_obs(data, paired),
     digits = digits,
     digits.df = digits.df
   )


### PR DESCRIPTION
## What liability was removed

`two_sample_test()` and `oneway_anova()` each carried an **identical** one-liner that computes the sample size `n` passed to `add_expression_col()`:

```r
n = ifelse(paired, length(unique(data$.rowid)), nrow(data))
```

Two verbatim copies of the same paired-aware counting logic is a maintenance hazard: any change to how the "number of subjects vs. number of rows" is derived from the `.rowid`-tagged data frame had to be made in two places and kept in sync.

## Source of the simplification

This is a pure **deduplication of the repo's own custom code** — no new dependency and no new dependency capability involved. It continues the recent series of deduplication cleanups (mean-difference effect-size selector, degrees-of-freedom templates, contingency-table counts prep).

## What was collapsed

- Added a single internal `@noRd` helper `.n_obs()` in `R/long-to-wide-converter.R`, right next to `long_to_wide_converter()` — the function that produces the `.rowid` column the helper relies on.
- Replaced both duplicated expressions with a one-line call to the helper.

Net: two identical inline expressions → one shared helper plus two one-line call sites, with the logic now living in exactly one place.

## How I ensured it stayed regression-free

- Behaviour is identical: the helper contains the exact same `ifelse(paired, length(unique(data$.rowid)), nrow(data))` expression that was inlined before, and both call sites pass the same `data`/`paired` in scope.
- Ran the affected test suites with `NOT_CRAN=true`, all passing:
  - `test-two-sample-parametric.R` — FAIL=0 PASS=9
  - `test-two-sample-nonparametric.R` — FAIL=0 PASS=5
  - `test-two-sample-robust.R` — FAIL=0 PASS=9
  - `test-two-sample-bayes.R` — FAIL=0 PASS=4
  - `test-oneway-anova-parametric.R` — FAIL=0 PASS=9
  - `test-oneway-anova-nonparametric.R` — FAIL=0 PASS=9
  - `test-oneway-anova-robust.R` — FAIL=0 PASS=8
  - `test-oneway-anova-bayes.R` — FAIL=0 PASS=22
  - `test-one-sample.R` — FAIL=0 PASS=32
- (The WRS2 `tr`/`trim` partial-match warnings in the robust path are pre-existing and unrelated to this change.)
- `lintr` reports no lints on the three changed files.

## `NEWS.md`

Not updated — this is a routine internal deduplication with no user-facing or behavioural change and no dependency version bump, which per the repo's changelog policy does not warrant a NEWS entry.