### PR TITLE
Deduplicate mean-difference test/effect-size selector

### DIFF
--- a/R/one-sample-test.R
+++ b/R/one-sample-test.R
@@ -56,23 +56,13 @@ one_sample_test <- function(
   type <- extract_stats_type(type)
   x_vec <- stats::na.omit(pull(data, {{ x }}))
 
-  # parametric ---------------------------------------
-
-  if (type == "parametric") {
-    .f <- stats::t.test
-    .f.es <- .mean_difference_effsize(effsize.type)
-  }
-
-  # non-parametric ---------------------------------------
-
-  if (type == "nonparametric") {
-    .f <- stats::wilcox.test
-    .f.es <- effectsize::rank_biserial
-  }
+  # parametric & non-parametric ---------------------------------------
 
   if (type %in% c("parametric", "nonparametric")) {
+    fns <- .mean_difference_fns(type, effsize.type)
+
     stats_df <- exec(
-      .f,
+      fns$test,
       x = x_vec,
       mu = test.value,
       alternative = alternative,
@@ -82,7 +72,7 @@ one_sample_test <- function(
       select(-matches("^est|^conf|^diff|^term|^ci"))
 
     ez_df <- exec(
-      .f.es,
+      fns$es,
       x = x_vec,
       mu = test.value,
       verbose = FALSE,

--- a/R/switch-functions.R
+++ b/R/switch-functions.R
@@ -118,3 +118,19 @@ prior_switch <- function(x) {
     biased = effectsize::cohens_d
   )
 }
+
+#' @title Select the test and effect-size functions for mean-difference tests
+#' @description Maps the statistical `type` to the base-R test function and its
+#'   companion `{effectsize}` function: the *parametric* approach pairs the
+#'   *t*-test with Hedges' *g* / Cohen's *d* (via [.mean_difference_effsize()]),
+#'   while the *non-parametric* approach pairs the Wilcoxon test with the
+#'   rank-biserial correlation. Shared by [one_sample_test()] and
+#'   [two_sample_test()].
+#' @noRd
+.mean_difference_fns <- function(type, effsize.type) {
+  if (type == "parametric") {
+    list(test = stats::t.test, es = .mean_difference_effsize(effsize.type))
+  } else {
+    list(test = stats::wilcox.test, es = effectsize::rank_biserial)
+  }
+}

--- a/R/two-sample-test.R
+++ b/R/two-sample-test.R
@@ -143,22 +143,17 @@ two_sample_test <- function(
     spread = ifelse(type %in% c("bayes", "robust"), paired, TRUE)
   )
 
-  # parametric ---------------------------------------
+  # parametric & non-parametric ------------------------------------
 
   if (type == "parametric") {
     digits.df <- ifelse(paired || var.equal, 0L, digits)
-    .f <- stats::t.test
-    .f.es <- .mean_difference_effsize(effsize.type)
-  }
-
-  # non-parametric ------------------------------------
-
-  if (type == "nonparametric") {
-    .f <- stats::wilcox.test
-    .f.es <- effectsize::rank_biserial
   }
 
   if (type %in% c("parametric", "nonparametric")) {
+    fns <- .mean_difference_fns(type, effsize.type)
+    .f <- fns$test
+    .f.es <- fns$es
+
     .f.args <- list(
       x = data[[2L]],
       y = data[[3L]],


### PR DESCRIPTION
## What liability was removed

`one_sample_test()` and `two_sample_test()` each carried an **identical**
block that maps the statistical `type` to the base-R test function *and* its
companion `{effectsize}` function:

```r
if (type == "parametric") {
  .f <- stats::t.test
  .f.es <- .mean_difference_effsize(effsize.type)
}
if (type == "nonparametric") {
  .f <- stats::wilcox.test
  .f.es <- effectsize::rank_biserial
}
```

Two verbatim copies of the same selection logic is a maintenance hazard: any
change to the parametric/non-parametric test or effect-size pairing had to be
made in two places and kept in sync.

## Source of the simplification

This is a pure **deduplication of the repo's own custom code** — no new
dependency and no new dependency capability involved. It is the direct
follow-on to #387 (which extracted `.mean_difference_effsize()`, the
effect-size selector shared by these same two functions) and continues the
recent series of deduplication cleanups.

## What was collapsed

- Added a single internal `@noRd` helper `.mean_difference_fns()` in
  `R/switch-functions.R`, alongside the existing statistics-selector family
  (`extract_stats_type()`, `.mean_difference_effsize()`, etc.). It returns the
  test/effect-size function pair for the requested `type`, reusing
  `.mean_difference_effsize()` for the parametric effect size.
- Replaced both duplicated selection blocks with a one-line call to the helper.
  In `one_sample_test()` the two separate `if` blocks collapse into the already
  existing combined `parametric`/`nonparametric` block; in `two_sample_test()`
  the parametric `digits.df` line is retained and only the `.f`/`.f.es`
  selection is delegated to the helper.

Net: two duplicated selection blocks → one shared helper plus concise call
sites (**26 insertions, 25 deletions**, shared logic now lives in one place).

## How I ensured it stayed regression-free

- Behaviour is identical: the helper returns the exact same functions that were
  inlined before (`stats::t.test` + `.mean_difference_effsize(effsize.type)`
  for parametric; `stats::wilcox.test` + `effectsize::rank_biserial` for
  non-parametric). The non-parametric branch still never evaluates
  `effsize.type`.
- Ran the affected test suites with `NOT_CRAN=true`, all passing:
  - `test-one-sample.R`
  - `test-one-two-sample-dataframes.R`
  - `test-two-sample-parametric.R`
  - `test-two-sample-nonparametric.R`
  - `test-two-sample-bayes.R`
  - `test-two-sample-robust.R`
- The `var.eq`/`tr` partial-argument-match warnings surfaced by these suites
  are pre-existing and unrelated to this change.
- `lintr` reports no lints on the three changed files.
- `roxygen2::roxygenise()` produces no changes to generated files (the helper
  is `@noRd`).

## `NEWS.md`

Not updated — this is a routine internal deduplication with no user-facing or
behavioural change and no dependency version bump, which per the repo's
changelog policy does not warrant a NEWS entry.
