### PR TITLE
Use tidyr for complete-case filtering

### DIFF
--- a/R/centrality-description.R
+++ b/R/centrality-description.R
@@ -62,7 +62,7 @@ centrality_description <- function(
 
   select(data, {{ x }}, {{ y }}) |>
     rename(!!group_name := {{ x }}, !!response_name := {{ y }}) |>
-    filter(!if_any(everything(), is.na)) |>
+    tidyr::drop_na() |>
     datawizard::describe_distribution(
       select = response_name,
       by = group_name,

--- a/R/contingency-table.R
+++ b/R/contingency-table.R
@@ -263,7 +263,7 @@ contingency_table <- function(
 .untable_by_counts <- function(data, x, y, counts) {
   data <- data |>
     select({{ x }}, {{ y }}, .counts = {{ counts }}) |>
-    filter(!if_any(everything(), is.na))
+    tidyr::drop_na()
 
   # untable the data frame based on the counts for each observation (if present)
   if (".counts" %in% names(data)) {

--- a/R/corr-test.R
+++ b/R/corr-test.R
@@ -44,7 +44,7 @@ corr_test <- function(
   type <- extract_stats_type(type)
 
   data <- select(ungroup(data), {{ x }}, {{ y }}) |>
-    filter(!if_any(everything(), is.na))
+    tidyr::drop_na()
 
   stats_df <- correlation::correlation(
     data = data,


### PR DESCRIPTION
## Summary

- replace three repeated complete-case predicates with `tidyr::drop_na()`
- use the existing `tidyr` dependency instead of maintaining custom `filter()` + `if_any()` logic
- preserve the selected-column scope and existing missing-data behavior in centrality, correlation, and contingency analyses

## Maintenance impact

The liability was duplicated custom complete-case filtering across three production paths. `tidyr::drop_na()` is the established dependency capability for retaining rows complete across all selected columns, so this collapses the repeated predicate into a single intention-revealing call at each site. No dependency was added and the existing `tidyr (>= 1.3.2)` constraint remains sufficient.

`NEWS.md` was not updated because this is a minor internal simplification with no user-facing behavior or compatibility change.

## Validation

- targeted tests: 79 passed across centrality, correlation, contingency-table, and pairwise-contingency coverage
- `make lint`
- `make hooks`
- `make check` (`Status: OK`)