### PR TITLE
Delegate incomplete-row filtering and stabilize README rendering

### DIFF
--- a/R/long-to-wide-converter.R
+++ b/R/long-to-wide-converter.R
@@ -81,7 +81,7 @@ long_to_wide_converter <- function(
     }
   }
 
-  data <- filter(data, !anyNA(pick({{ x }}, {{ y }})), .by = .rowid)
+  data <- filter_out(data, anyNA(pick({{ x }}, {{ y }})), .by = .rowid)
 
   # convert to wide?
   if (spread) {

--- a/R/tidy-model-expressions.R
+++ b/R/tidy-model-expressions.R
@@ -59,10 +59,7 @@ tidy_model_expressions <- function(
   # expression corresponding to that row; convert the necessary columns to
   # character type for expression
   df_expr <- data |>
-    filter(if_all(
-      .cols = matches("estimate|statistic|std.error|p.value"),
-      .fns = Negate(is.na)
-    )) |>
+    tidyr::drop_na(matches("estimate|statistic|std.error|p.value")) |>
     .data_to_char(digits)
 
   stat_type <- statistic

--- a/README.Rmd
+++ b/README.Rmd
@@ -5,7 +5,9 @@ output: github_document
   <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 ```{r}
-#| echo = FALSE
+#| echo = FALSE,
+#| message = FALSE,
+#| warning = FALSE
 options(pillar.width = Inf, pillar.bold = TRUE, pillar.subtle_num = TRUE)
 
 knitr::opts_chunk$set(
@@ -29,8 +31,10 @@ Status | Usage | Miscellaneous
 [![R build status](https://github.com/IndrajeetPatil/statsExpressions/workflows/R-CMD-check/badge.svg)](https://github.com/IndrajeetPatil/statsExpressions/actions) | [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/statsExpressions?color=blue)](https://CRAN.R-project.org/package=statsExpressions) | [![Codecov](https://codecov.io/gh/IndrajeetPatil/statsExpressions/branch/main/graph/badge.svg)](https://app.codecov.io/gh/IndrajeetPatil/statsExpressions?branch=main)
 [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html) | [![Daily downloads](https://cranlogs.r-pkg.org/badges/last-day/statsExpressions?color=blue)](https://CRAN.R-project.org/package=statsExpressions) | [![DOI](https://joss.theoj.org/papers/10.21105/joss.03236/status.svg)](https://doi.org/10.21105/joss.03236)
 
+```{=gfm}
 > [!NOTE]
 > This package supports R-devel, the current R release, and the previous R release.
+```
 
 # Introduction <img src="man/figures/logo.png" alt="statsExpressions package logo" align="right" width="240" />
 


### PR DESCRIPTION
## Summary

- replace the remaining hand-written incomplete-row predicates with dependency APIs designed for that intent
- use dplyr::filter_out() for grouped subject-level removal and tidyr::drop_na() for selected expression inputs
- collapse five lines of negation and predicate plumbing to two direct calls while preserving selected-column and grouped behavior
- make README rendering suppress setup warnings and preserve the GitHub note syntax with current Pandoc

## Maintenance impact

The code liability was custom negative missingness logic in two production paths. Current dplyr provides filter_out() with per-operation .by grouping, and tidyr provides drop_na() with tidy-select support. Using those established capabilities leaves less predicate machinery to maintain. No dependency was added or bumped because DESCRIPTION already requires dplyr >= 1.2.1 and tidyr >= 1.3.2.

README.md was rendered from README.Rmd. The generated Markdown content is current and unchanged; only the source needed safeguards against a local package-build warning and Pandoc escaping the GitHub note marker. Byte-only local plot churn was excluded.

NEWS.md was not updated because these are internal maintenance changes with no user-facing behavior or compatibility change.

## Regression evidence

- exact pre-edit equivalence probes: five grouped missing-data cases and four selected-column expression cases
- focused tests for long_to_wide_converter() and tidy_model_expressions()
- README rendered successfully from README.Rmd
- make lint
- make hooks
- make check (Status: OK)
- git diff --check