### PR TITLE
chore: CRAN Release 2.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: statsExpressions
 Title: Tidy Dataframes and Expressions with Statistical Details
-Version: 2.1.0
+Version: 2.1.1
 Authors@R:
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = c("cre", "aut", "cph"),
            comment = c(ORCID = "0000-0003-1995-6531"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# statsExpressions 2.1.1
+
+- Simple internal refactorings.
+
 # statsExpressions 2.1.0
 
 - The minimum supported R version is now 4.5. The project supports R-devel,

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/IndrajeetPatil/statsExpressions",
   "issueTracker": "https://github.com/IndrajeetPatil/statsExpressions/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,7 +2,7 @@
 
 0 errors | 0 warnings | 0 notes
 
-- Minor release (2.1.0)
+- Patch release (2.1.1)
 
 ## revdepcheck results
 


### PR DESCRIPTION
## Summary

- prepare the 2.1.1 patch CRAN release across DESCRIPTION, NEWS.md, and codemeta.json
- summarize the behavior-preserving internal refactorings since 2.1.0 in one succinct NEWS item
- update cran-comments.md to identify this as a patch release with 0 errors, warnings, or notes
- leave dependency constraints unchanged

## Validation

- air format . --check
- make lint
- make hooks
- make check (Status: OK)
- git diff --check