### PR TITLE
Use partial replacement for p-adjust labels

### DIFF
--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -300,12 +300,8 @@ pairwise_comparisons <- function(
 
 #' @noRd
 .pairwise_p_adjust_expr <- function(data, p.adjust.method, digits, test) {
-  method_label <- insight::format_capitalize(p.adjust.method)
-  method_label <- recode_values(
-    method_label,
-    c("BH", "Fdr") ~ "FDR",
-    default = method_label
-  )
+  method_label <- insight::format_capitalize(p.adjust.method) |>
+    replace_values(c("BH", "Fdr") ~ "FDR")
 
   data |>
     mutate(


### PR DESCRIPTION
## Summary

- replace a complete `recode_values()` call plus its explicit fallback with `dplyr::replace_values()`, the dependency API intended for partial updates
- preserve `BH` and `fdr` normalization to `FDR` while retaining all other formatted adjustment labels unchanged
- collapse the label setup from two assignments and six lines to one two-line pipeline

## Maintenance benefit

The package no longer owns fallback plumbing for unmatched labels. `replace_values()` preserves unmatched input values by contract, so the code now directly expresses the operation it performs. The API was introduced in dplyr 1.2.0 and is already covered by the existing `dplyr (>= 1.2.1)` requirement, so `DESCRIPTION` and `codemeta.json` do not need changes.

`NEWS.md` was not updated because this is a minor internal simplification with no user-visible or compatibility change.

## Validation

- exact equivalence probe across all supported adjustment methods, including values, types, names, and attributes
- focused pairwise tests with `NOT_CRAN=true` (60 passed)
- `make lint`
- `make hooks`
- `make check` (`Status: OK`)
- `git diff --check`