### PR TITLE
Call WRS2 pairwise APIs directly

### DIFF
--- a/R/pairwise-comparisons.R
+++ b/R/pairwise-comparisons.R
@@ -231,24 +231,13 @@ pairwise_comparisons <- function(
   # robust ----------------------------------
 
   if (type == "robust") {
-    if (!paired) {
-      .ns <- "WRS2"
-      .fn <- "lincon"
-      .f.args <- list(formula = new_formula(y, x), data = data, method = "none")
+    df_pair <- if (paired) {
+      WRS2::rmmcp(y = y_vec, groups = x_vec, blocks = g_vec, tr = tr)
+    } else {
+      WRS2::lincon(new_formula(y, x), data, tr = tr, method = "none")
     }
 
-    if (paired) {
-      .ns <- "WRS2"
-      .fn <- "rmmcp"
-      .f.args <- list(
-        y = quote(y_vec),
-        groups = quote(x_vec),
-        blocks = quote(g_vec)
-      )
-    }
-
-    df_pair <- eval(call2(.ns = .ns, .fn = .fn, tr = tr, !!!.f.args)) |>
-      tidy_model_parameters()
+    df_pair <- tidy_model_parameters(df_pair)
     test <- "Yuen's trimmed means"
   }
 


### PR DESCRIPTION
## Summary

- replace the custom namespace/function-name dispatch for robust pairwise comparisons with direct calls to `WRS2::lincon()` and `WRS2::rmmcp()`
- remove the intermediate `.ns`, `.fn`, and `.f.args` plumbing plus `eval(call2())`
- keep the shared `tidy_model_parameters()` normalization after method selection

## Why this is simpler

The package already depends on WRS2, whose documented APIs directly cover independent and repeated-measures robust pairwise comparisons. Calling those APIs directly removes 11 net lines and avoids maintaining string-based call construction, quoted argument lists, and manual evaluation without adding a dependency or changing the statistical methods.

## Regression safeguards

- compared the old and new WRS2 results directly: paired raw objects were identical, and paired/unpaired tidied outputs were identical including attributes
- ran the existing robust pairwise snapshot coverage for both between- and within-subjects designs; all 43 expectations passed with unchanged snapshots
- confirmed the focused baseline and branch runs emit the same 15 pre-existing WRS2 partial-argument-match warnings
- `make lint`
- `make hooks`
- `make check` (`Status: OK`)
- `git diff --check`

## Changelog

`NEWS.md` was not updated because this is a minor internal simplification with no dependency-version or user-visible behavior change.
