### PR TITLE
Call WRS2 mean-difference APIs directly

### DIFF
--- a/R/one-sample-test.R
+++ b/R/one-sample-test.R
@@ -86,8 +86,7 @@ one_sample_test <- function(
   # robust ---------------------------------------
 
   if (type == "robust") {
-    stats_df <- exec(
-      WRS2::trimcibt,
+    stats_df <- WRS2::trimcibt(
       x = x_vec,
       nv = test.value,
       tr = tr,

--- a/R/two-sample-test.R
+++ b/R/two-sample-test.R
@@ -177,35 +177,28 @@ two_sample_test <- function(
   if (type == "robust") {
     digits.df <- ifelse(paired, 0L, digits)
 
-    # styler: off
-    if (!paired) {
-      .f <- WRS2::yuen
-      .f.es <- WRS2::akp.effect
-    }
     if (paired) {
-      .f <- WRS2::yuend
-      .f.es <- WRS2::dep.effect
+      effect_model <- WRS2::dep.effect(
+        x = data[[2L]],
+        y = data[[3L]],
+        tr = tr,
+        nboot = nboot
+      )
+      test_model <- WRS2::yuend(x = data[[2L]], y = data[[3L]], tr = tr)
+    } else {
+      effect_model <- WRS2::akp.effect(
+        formula = new_formula(y, x),
+        data = data,
+        EQVAR = FALSE,
+        tr = tr,
+        nboot = nboot,
+        alpha = 1.0 - conf.level
+      )
+      test_model <- WRS2::yuen(new_formula(y, x), data, tr = tr)
     }
 
-    .f.args <- list(
-      formula = new_formula(y, x),
-      data = data,
-      x = data[[2L]],
-      y = data[[3L]]
-    )
-    .f.es.args <- list(
-      EQVAR = FALSE,
-      nboot = nboot,
-      alpha = 1.0 - conf.level,
-      tr = tr
-    )
-
-    ez_df <- tidy_model_parameters(
-      exec(.f.es, !!!.f.args, !!!.f.es.args),
-      keep = "AKP"
-    )
-    stats_df <- tidy_model_parameters(exec(.f, !!!.f.args, !!!.f.es.args))
-    # styler: on
+    ez_df <- tidy_model_parameters(effect_model, keep = "AKP")
+    stats_df <- tidy_model_parameters(test_model)
   }
 
   if (type != "bayes") {


### PR DESCRIPTION
## Summary

- replace the remaining dynamic WRS2 dispatch for robust one- and two-sample mean-difference tests with direct public API calls
- call trimcibt(), dep.effect(), yuend(), akp.effect(), and yuen() with only the arguments each function consumes
- remove the intermediate function selectors, shared catch-all argument lists, exec() calls, and formatter overrides while retaining the existing result normalization

## Why this is simpler

The package already depends on the reliable WRS2 package at version 1.1-7 or newer, and its public APIs directly cover all of these robust mean-difference paths. The previous implementation dynamically selected functions and sent every possible formula, data, vector, bootstrap, and confidence argument through ellipses, relying on each WRS2 function to ignore irrelevant inputs. Direct calls make the paired and independent contracts explicit and remove 8 net lines of repository-owned dispatch plumbing without adding or upgrading a dependency.

## Regression safeguards

- inspected the WRS2 1.1-7 public function signatures for all five APIs
- compared the old and new seeded pipelines directly: paired and unpaired tidied results were identical including attributes, and the one-sample raw and tidied results were identical
- ran the focused one-sample and robust two-sample suite; all 41 expectations passed with unchanged data-frame and plotmath snapshots
- make lint
- make hooks
- make check (Status: OK)
- git diff --check

## Changelog

NEWS.md was not updated because this is a minor internal simplification with no dependency-version or user-visible behavior change.
