### PR TITLE
Call meta-analysis backends directly

### DIFF
--- a/R/meta-analysis.R
+++ b/R/meta-analysis.R
@@ -76,38 +76,35 @@ meta_analysis <- function(
 ) {
   type <- extract_stats_type(type)
 
-  # nolint start: line_length_linter.
-  .meta_args <- switch(
+  check_if_installed(switch(
     type,
-    parametric = list(
-      .ns = "metafor",
-      .fn = "rma",
-      .f.args = list(yi = quote(estimate), sei = quote(std.error), ...)
-    ),
-    robust = list(
-      .ns = "metaplus",
-      .fn = "metaplus",
-      .f.args = list(
-        yi = quote(estimate),
-        sei = quote(std.error),
-        random = random,
-        ...
-      )
-    ),
-    bayes = list(
-      .ns = "metaBMA",
-      .fn = "meta_random",
-      .f.args = list(y = quote(estimate), SE = quote(std.error), ...)
-    )
-  )
-  .ns <- .meta_args$.ns
-  .fn <- .meta_args$.fn
-  .f.args <- .meta_args$.f.args
-  # nolint end
+    parametric = "metafor",
+    robust = "metaplus",
+    bayes = "metaBMA"
+  ))
 
-  check_if_installed(.ns)
-
-  stats_df <- eval(call2(.fn = .fn, .ns = .ns, data = data, !!!.f.args)) |>
+  stats_df <- switch(
+    type,
+    parametric = inject(metafor::rma(
+      yi = !!sym("estimate"),
+      sei = !!sym("std.error"),
+      data = !!data,
+      ...
+    )),
+    robust = inject(metaplus::metaplus(
+      yi = !!sym("estimate"),
+      sei = !!sym("std.error"),
+      random = random,
+      data = !!data,
+      ...
+    )),
+    bayes = inject(metaBMA::meta_random(
+      y = !!sym("estimate"),
+      SE = !!sym("std.error"),
+      data = !!data,
+      ...
+    ))
+  ) |>
     tidy_model_parameters(include_studies = FALSE, ci = conf.level)
 
   if (type != "bayes") {


### PR DESCRIPTION
## Summary

- replace the hand-built namespace, function-name, and quoted-argument bundles in meta_analysis() with direct metafor::rma(), metaplus::metaplus(), and metaBMA::meta_random() calls
- use the already-required rlang::inject() API to preserve each backend model call and downstream data recovery
- retain the explicit optional-package availability check and the existing result normalization

## Why this is simpler

The package already delegates the statistical work to these mature third-party backends and already imports rlang. Calling their public APIs directly removes the intermediate metadata lists, temporary namespace/function variables, nolint wrapper, and eval(call2()) execution path. This reduces repository-owned dispatch plumbing without adding or upgrading a dependency.

## Regression safeguards

- confirmed the current backend signatures, including the metafor yi/sei/data contract from first-party documentation
- compared the old and new seeded pipelines directly for parametric, robust, and Bayesian meta-analysis; final tibbles, classes, attributes, and plotmath expressions were identical
- verified forwarded metafor options and existing invalid-input error behavior remain identical
- focused meta-analysis tests: 8 expectations passed with unchanged snapshots
- make lint
- make hooks
- make check (Status: OK)
- git diff --check

## Changelog

NEWS.md was not updated because this is a minor internal simplification with no dependency-version or user-visible behavior change.