### PR TITLE
Call nonparametric ANOVA APIs directly

### DIFF
--- a/R/oneway-anova.R
+++ b/R/oneway-anova.R
@@ -214,43 +214,32 @@ oneway_anova <- function(
     digits.df <- 0L
     digits.df.error <- 0L
 
-    # styler: off
     if (paired) {
-      .f <- stats::friedman.test
-      .f.es <- effectsize::kendalls_w
-      .f.args <- list(
-        formula = new_formula(
-          enexpr(y),
-          expr(!!enexpr(x) | .rowid)
-        )
-      )
-      .f.es.args <- list(
-        x = new_formula(
-          enexpr(y),
-          expr(!!enexpr(x) | .rowid)
-        )
+      test_formula <- new_formula(enexpr(y), expr(!!enexpr(x) | .rowid))
+      test_model <- stats::friedman.test(test_formula, data = data)
+      effect_model <- effectsize::kendalls_w(
+        x = test_formula,
+        data = data,
+        ci = conf.level,
+        iterations = nboot,
+        verbose = FALSE
       )
     }
 
     if (!paired) {
-      .f <- stats::kruskal.test
-      .f.es <- effectsize::rank_epsilon_squared
-      .f.args <- list(formula = new_formula(y, x))
-      .f.es.args <- list(x = new_formula(y, x))
+      test_formula <- new_formula(y, x)
+      test_model <- stats::kruskal.test(test_formula, data = data)
+      effect_model <- effectsize::rank_epsilon_squared(
+        x = test_formula,
+        data = data,
+        ci = conf.level,
+        iterations = nboot,
+        verbose = FALSE
+      )
     }
-    # styler: on
 
-    stats_df <- tidy_model_parameters(exec(.f, !!!.f.args, data = data))
-
-    ez_df <- exec(
-      .fn = .f.es,
-      data = data,
-      ci = conf.level,
-      iterations = nboot,
-      verbose = FALSE,
-      !!!.f.es.args
-    ) |>
-      tidy_model_effectsize()
+    stats_df <- tidy_model_parameters(test_model)
+    ez_df <- tidy_model_effectsize(effect_model)
 
     stats_df <- bind_cols(stats_df, ez_df)
   }


### PR DESCRIPTION
## Summary

- call `stats::friedman.test()` and `effectsize::kendalls_w()` directly for repeated-measures nonparametric ANOVA
- call `stats::kruskal.test()` and `effectsize::rank_epsilon_squared()` directly for between-subjects nonparametric ANOVA
- construct each branch's formula once and retain the existing result normalization

## Why this is simpler

The package already delegates these analyses to stable public APIs from base R and the already-required `effectsize` dependency. Calling those APIs directly removes the repository-owned function selectors, duplicated formula argument bundles, `styler` override, and dynamic `rlang::exec()` plumbing. The change removes 11 net lines without adding or upgrading a dependency.

## Regression safeguards

- confirmed the current `effectsize` signatures for `kendalls_w()` and `rank_epsilon_squared()`
- compared the old dynamic-dispatch and new direct-call pipelines at non-default confidence levels for both paired and unpaired designs; normalized results and RNG state were identical
- focused nonparametric ANOVA tests: 9 expectations passed with unchanged snapshots
- `make lint`
- `make hooks`
- `make check` (`Status: OK`)
- `git diff --check`

## Changelog

`NEWS.md` was not updated because this is a minor internal simplification with no dependency-version or user-visible behavior change.
