### PR TITLE
Call contingency table APIs directly

### DIFF
--- a/R/contingency-table.R
+++ b/R/contingency-table.R
@@ -165,33 +165,21 @@ contingency_table <- function(
 
   # non-Bayesian ---------------------------------------
 
-  if (type != "bayes" && test == "2way") {
-    if (paired) {
-      .f <- stats::mcnemar.test
-      .f.es <- effectsize::cohens_g
-    }
-    if (!paired) {
-      .f <- stats::chisq.test
-      .f.es <- effectsize::cramers_v
-    }
-    .f.args <- list(x = xtab, correct = FALSE)
-  }
-
-  if (type != "bayes" && test == "1way") {
-    .f <- stats::chisq.test
-    .f.es <- effectsize::pearsons_c
-    .f.args <- list(x = xtab, p = ratio, correct = FALSE)
-  }
-
   if (type != "bayes") {
+    if (test == "1way") {
+      test_model <- stats::chisq.test(x = xtab, p = ratio, correct = FALSE)
+      effect_model <- effectsize::pearsons_c(xtab, p = ratio, ci = conf.level, alternative = alternative)
+    } else if (paired) {
+      test_model <- stats::mcnemar.test(x = xtab, correct = FALSE)
+      effect_model <- effectsize::cohens_g(xtab, ci = conf.level, alternative = alternative)
+    } else {
+      test_model <- stats::chisq.test(x = xtab, correct = FALSE)
+      effect_model <- effectsize::cramers_v(xtab, ci = conf.level, alternative = alternative)
+    }
+
     stats_df <- bind_cols(
-      tidy_model_parameters(exec(.f, !!!.f.args)),
-      tidy_model_effectsize(exec(
-        .f.es,
-        !!!.f.args,
-        ci = conf.level,
-        alternative = alternative
-      ))
+      tidy_model_parameters(test_model),
+      tidy_model_effectsize(effect_model)
     )
   }
 

--- a/R/contingency-table.R
+++ b/R/contingency-table.R
@@ -168,13 +168,26 @@ contingency_table <- function(
   if (type != "bayes") {
     if (test == "1way") {
       test_model <- stats::chisq.test(x = xtab, p = ratio, correct = FALSE)
-      effect_model <- effectsize::pearsons_c(xtab, p = ratio, ci = conf.level, alternative = alternative)
+      effect_model <- effectsize::pearsons_c(
+        xtab,
+        p = ratio,
+        ci = conf.level,
+        alternative = alternative
+      )
     } else if (paired) {
       test_model <- stats::mcnemar.test(x = xtab, correct = FALSE)
-      effect_model <- effectsize::cohens_g(xtab, ci = conf.level, alternative = alternative)
+      effect_model <- effectsize::cohens_g(
+        xtab,
+        ci = conf.level,
+        alternative = alternative
+      )
     } else {
       test_model <- stats::chisq.test(x = xtab, correct = FALSE)
-      effect_model <- effectsize::cramers_v(xtab, ci = conf.level, alternative = alternative)
+      effect_model <- effectsize::cramers_v(
+        xtab,
+        ci = conf.level,
+        alternative = alternative
+      )
     }
 
     stats_df <- bind_cols(


### PR DESCRIPTION
## Summary

- call `stats::chisq.test()`, `stats::mcnemar.test()`, `effectsize::pearsons_c()`, `effectsize::cohens_g()`, and `effectsize::cramers_v()` directly in the non-Bayesian contingency-table branches
- remove repository-owned function selectors, the shared catch-all argument bundle, ignored effect-size arguments, and dynamic `rlang::exec()` dispatch
- keep the existing result normalization and output contracts unchanged

## Why this is simpler

The package already delegates these analyses to public APIs from base R and the mature, already-required `effectsize` dependency. Calling those APIs directly collapses two function-selection blocks and a later execution block into one explicit branch without adding or upgrading a dependency. The Air-formatted diff adds one net source line, but removes the function-valued selectors, argument-bundle plumbing, and dynamic dispatch that made the control flow harder to follow and maintain.

## Regression safeguards

- confirmed the current public `effectsize` signatures for `cohens_g()`, `cramers_v()`, and `pearsons_c()`
- compared the old dynamic-dispatch and new direct-call pipelines for one-way, paired two-way, and unpaired two-way tables at a non-default confidence level and one-sided alternative; values, classes, attributes, warnings, and messages were identical
- focused contingency-table tests with `NOT_CRAN=true`: 42 expectations passed with unchanged snapshots
- `air format . --check`
- `make lint`
- `make hooks`
- `make check` (`Status: OK`)
- `git diff --check`

## Changelog

`NEWS.md` was not updated because this is a minor internal simplification with no dependency-version or user-visible behavior change.