### PR TITLE
docs: add return-value schema article and expand @returns documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # statsExpressions 2.1.1
 
+- New _Return value schema_ article documenting, for each exported function, the
+  full set of returned tibble columns (including the preformatted `expression`
+  and `n.expression` columns) and the role of the internal `add_expression_col()`
+  engine. The shared `@returns` documentation has also been expanded to cover
+  previously undocumented columns (e.g. `bf10`, `log_e_bf10`, `prior.scale`,
+  `group1`/`group2`, `p.value.adj`).
+
 - Simple internal refactorings.
 
 # statsExpressions 2.1.0

--- a/R/centrality-description.R
+++ b/R/centrality-description.R
@@ -20,6 +20,11 @@
 #' ```{r child="man/rmd-fragments/centrality_description.Rmd"}
 #' ```
 #'
+#' @returns
+#'
+#' ```{r child="man/rmd-fragments/return.Rmd"}
+#' ```
+#'
 #' @param x The grouping (or independent) variable in `data`.
 #' @inheritParams oneway_anova
 #' @param ... Currently ignored.

--- a/R/centrality-description.R
+++ b/R/centrality-description.R
@@ -22,7 +22,7 @@
 #'
 #' @returns
 #'
-#' ```{r child="man/rmd-fragments/return.Rmd"}
+#' ```{r child="man/rmd-fragments/return_centrality.Rmd"}
 #' ```
 #'
 #' @param x The grouping (or independent) variable in `data`.

--- a/man/centrality_description.Rd
+++ b/man/centrality_description.Rd
@@ -54,63 +54,38 @@ significant figures (see also \code{\link[=signif]{signif()}}).}
 }
 \value{
 The returned object is a tibble data frame with the additional class
-\code{"statsExpressions"}. The exact set of columns depends on the statistical test
-and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
-any given call returns \emph{some} (not all) of the columns below.
-
-\strong{Hypothesis testing}
+\code{"statsExpressions"}. Unlike the hypothesis-testing functions, this one returns
+one row \strong{per level} of the grouping variable \code{x}, describing the distribution
+of \code{y} within that level. The columns are:
 \itemize{
-\item \code{statistic}: the numeric value of a statistic
-\item \code{df}: the numeric value of a parameter being modeled (often degrees
-of freedom for the test)
-\item \code{df.error} and \code{df}: relevant only if the statistic in question has
-two degrees of freedom (e.g. anova)
-\item \code{p.value}: the two-sided \emph{p}-value associated with the observed statistic
-\item \code{method}: the name of the inferential statistical test
+\item the grouping variable (named after \code{x}, e.g. \code{Species})
+\item the requested centrality estimate (named after \code{y}, e.g. \code{Sepal.Length}):
+the mean (\code{type = "parametric"}), median (\code{"nonparametric"}), trimmed mean
+(\code{"robust"}), or MAP estimate (\code{"bayes"})
+\item \code{std.dev}: standard deviation (for \code{"parametric"} and \code{"robust"})
+\item \code{mad}: median absolute deviation (for \code{"nonparametric"})
+\item \code{iqr}: interquartile range
+\item \code{conf.low}, \code{conf.high}: bounds of the confidence/credible interval for the
+centrality estimate
+\item \code{min}, \code{max}: minimum and maximum values
+\item \code{skewness}, \code{kurtosis}: shape statistics of the distribution
+\item \code{n.obs}: number of non-missing observations
+\item \code{missing.obs}: number of missing observations
+\item \code{expression}: a list-column of pre-formatted
+\href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath} expressions (each
+element is a \code{language} object, not a character string) containing the
+centrality estimate, ready to be used in \code{{ggplot2}}
+\item \code{n.expression}: a label combining the group name and its sample size (e.g.
+\code{"setosa\\n(n = 50)"}), useful as an axis or facet label
 }
 
-\strong{Effect size estimation}
-\itemize{
-\item \code{effectsize}: the name of the effect size
-\item \code{estimate}: estimated value of the effect size
-\item \code{conf.level}: width of the confidence/credible interval
-\item \code{conf.low}: lower bound for the effect size estimate
-\item \code{conf.high}: upper bound for the effect size estimate
-\item \code{conf.method}: method used to compute the confidence/credible interval
-\item \code{conf.distribution}: statistical distribution for the effect
-}
+The exact dispersion column depends on the \code{type} of analysis (\code{std.dev} vs
+\code{mad}), and \code{datawizard::describe_distribution()} is used internally to compute
+these indices.
 
-\strong{Bayesian analysis} (only when \code{type = "bayes"})
-\itemize{
-\item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
-\item \code{log_e_bf10}: natural logarithm of the Bayes factor
-\item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
-used to compute the Bayes factor and posterior estimates
-}
-
-\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
-\code{pairwise_contingency_table()})
-\itemize{
-\item \code{group1}, \code{group2}: the two levels being compared
-\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
-\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
-}
-
-\strong{Common columns}
-\itemize{
-\item \code{n.obs}: number of observations
-\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
-expression (a \code{language} object, not a character string) containing the
-statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
-\code{annotate()})
-\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
-group name and its sample size, useful as an axis or facet label
-}
-
-For a per-function, column-by-column breakdown of the output (and an explanation
-of the internal \code{add_expression_col()} engine that builds the \code{expression}
-column), see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html}{Return value schema}
-article. For more examples, see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+For more examples, see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}
+and the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html}{Return value schema}
+article.
 }
 \description{
 Parametric, non-parametric, robust, and Bayesian measures of centrality.

--- a/man/centrality_description.Rd
+++ b/man/centrality_description.Rd
@@ -52,6 +52,66 @@ significant figures (see also \code{\link[=signif]{signif()}}).}
 
 \item{...}{Currently ignored.}
 }
+\value{
+The returned object is a tibble data frame with the additional class
+\code{"statsExpressions"}. The exact set of columns depends on the statistical test
+and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
+any given call returns \emph{some} (not all) of the columns below.
+
+\strong{Hypothesis testing}
+\itemize{
+\item \code{statistic}: the numeric value of a statistic
+\item \code{df}: the numeric value of a parameter being modeled (often degrees
+of freedom for the test)
+\item \code{df.error} and \code{df}: relevant only if the statistic in question has
+two degrees of freedom (e.g. anova)
+\item \code{p.value}: the two-sided \emph{p}-value associated with the observed statistic
+\item \code{method}: the name of the inferential statistical test
+}
+
+\strong{Effect size estimation}
+\itemize{
+\item \code{effectsize}: the name of the effect size
+\item \code{estimate}: estimated value of the effect size
+\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.low}: lower bound for the effect size estimate
+\item \code{conf.high}: upper bound for the effect size estimate
+\item \code{conf.method}: method used to compute the confidence/credible interval
+\item \code{conf.distribution}: statistical distribution for the effect
+}
+
+\strong{Bayesian analysis} (only when \code{type = "bayes"})
+\itemize{
+\item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
+used to compute the Bayes factor and posterior estimates
+}
+
+\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\code{pairwise_contingency_table()})
+\itemize{
+\item \code{group1}, \code{group2}: the two levels being compared
+\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
+\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+}
+
+\strong{Common columns}
+\itemize{
+\item \code{n.obs}: number of observations
+\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
+expression (a \code{language} object, not a character string) containing the
+statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
+\code{annotate()})
+\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
+group name and its sample size, useful as an axis or facet label
+}
+
+For a per-function, column-by-column breakdown of the output (and an explanation
+of the internal \code{add_expression_col()} engine that builds the \code{expression}
+column), see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html}{Return value schema}
+article. For more examples, see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+}
 \description{
 Parametric, non-parametric, robust, and Bayesian measures of centrality.
 }

--- a/man/contingency_table.Rd
+++ b/man/contingency_table.Rd
@@ -92,7 +92,12 @@ hypothesis under the alternative, and corresponds to Gunel and Dickey's
 \item{...}{Additional arguments (currently ignored).}
 }
 \value{
-The returned tibble data frame can contain some or all of the following columns (the exact columns will depend on the statistical test):
+The returned object is a tibble data frame with the additional class
+\code{"statsExpressions"}. The exact set of columns depends on the statistical test
+and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
+any given call returns \emph{some} (not all) of the columns below.
+
+\strong{Hypothesis testing}
 \itemize{
 \item \code{statistic}: the numeric value of a statistic
 \item \code{df}: the numeric value of a parameter being modeled (often degrees
@@ -101,18 +106,50 @@ of freedom for the test)
 two degrees of freedom (e.g. anova)
 \item \code{p.value}: the two-sided \emph{p}-value associated with the observed statistic
 \item \code{method}: the name of the inferential statistical test
-\item \code{estimate}: estimated value of the effect size
-\item \code{conf.low}: lower bound for the effect size estimate
-\item \code{conf.high}: upper bound for the effect size estimate
-\item \code{conf.level}: width of the confidence interval
-\item \code{conf.method}: method used to compute confidence interval
-\item \code{conf.distribution}: statistical distribution for the effect
-\item \code{effectsize}: the name of the effect size
-\item \code{n.obs}: number of observations
-\item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+\strong{Effect size estimation}
+\itemize{
+\item \code{effectsize}: the name of the effect size
+\item \code{estimate}: estimated value of the effect size
+\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.low}: lower bound for the effect size estimate
+\item \code{conf.high}: upper bound for the effect size estimate
+\item \code{conf.method}: method used to compute the confidence/credible interval
+\item \code{conf.distribution}: statistical distribution for the effect
+}
+
+\strong{Bayesian analysis} (only when \code{type = "bayes"})
+\itemize{
+\item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
+used to compute the Bayes factor and posterior estimates
+}
+
+\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\code{pairwise_contingency_table()})
+\itemize{
+\item \code{group1}, \code{group2}: the two levels being compared
+\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
+\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+}
+
+\strong{Common columns}
+\itemize{
+\item \code{n.obs}: number of observations
+\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
+expression (a \code{language} object, not a character string) containing the
+statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
+\code{annotate()})
+\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
+group name and its sample size, useful as an axis or facet label
+}
+
+For a per-function, column-by-column breakdown of the output (and an explanation
+of the internal \code{add_expression_col()} engine that builds the \code{expression}
+column), see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html}{Return value schema}
+article. For more examples, see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric and Bayesian one-way and two-way contingency table analyses.

--- a/man/contingency_table.Rd
+++ b/man/contingency_table.Rd
@@ -93,9 +93,10 @@ hypothesis under the alternative, and corresponds to Gunel and Dickey's
 }
 \value{
 The returned object is a tibble data frame with the additional class
-\code{"statsExpressions"}. The exact set of columns depends on the statistical test
-and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
-any given call returns \emph{some} (not all) of the columns below.
+\code{"statsExpressions"}. The exact set of columns depends on the test and, for
+functions that accept a \code{type} argument, on the chosen analysis (parametric,
+non-parametric, robust, or Bayesian). Any given call therefore returns \emph{some}
+(not all) of the columns below.
 
 \strong{Hypothesis testing}
 \itemize{
@@ -112,7 +113,8 @@ two degrees of freedom (e.g. anova)
 \itemize{
 \item \code{effectsize}: the name of the effect size
 \item \code{estimate}: estimated value of the effect size
-\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.level}: the coverage level of the confidence/credible interval
+(e.g. \code{0.95}); the interval itself spans \code{conf.low} to \code{conf.high}
 \item \code{conf.low}: lower bound for the effect size estimate
 \item \code{conf.high}: upper bound for the effect size estimate
 \item \code{conf.method}: method used to compute the confidence/credible interval
@@ -122,28 +124,31 @@ two degrees of freedom (e.g. anova)
 \strong{Bayesian analysis} (only when \code{type = "bayes"})
 \itemize{
 \item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
-\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor (present for most, but
+not all, Bayesian analyses)
 \item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
 used to compute the Bayes factor and posterior estimates
 }
 
-\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\strong{Pairwise comparisons} (for \code{pairwise_comparisons()} and
 \code{pairwise_contingency_table()})
 \itemize{
 \item \code{group1}, \code{group2}: the two levels being compared
-\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
-\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+\item \code{p.adjust.method}: the adjustment method used for multiple comparisons
+\item \code{p.value.adj}: the adjusted \emph{p}-value; returned by
+\code{pairwise_contingency_table()}. Note that \code{pairwise_comparisons()} instead
+folds the adjusted value into \code{p.value} (and does not return a separate
+\code{p.value.adj} column)
 }
 
 \strong{Common columns}
 \itemize{
 \item \code{n.obs}: number of observations
-\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
-expression (a \code{language} object, not a character string) containing the
+\item \code{expression}: a list-column of pre-formatted
+\href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath} expressions; each
+element is a \code{language} object (not a character string) containing the
 statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
 \code{annotate()})
-\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
-group name and its sample size, useful as an axis or facet label
 }
 
 For a per-function, column-by-column breakdown of the output (and an explanation

--- a/man/corr_test.Rd
+++ b/man/corr_test.Rd
@@ -64,9 +64,10 @@ value corresponds to scale for fixed effects.}
 }
 \value{
 The returned object is a tibble data frame with the additional class
-\code{"statsExpressions"}. The exact set of columns depends on the statistical test
-and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
-any given call returns \emph{some} (not all) of the columns below.
+\code{"statsExpressions"}. The exact set of columns depends on the test and, for
+functions that accept a \code{type} argument, on the chosen analysis (parametric,
+non-parametric, robust, or Bayesian). Any given call therefore returns \emph{some}
+(not all) of the columns below.
 
 \strong{Hypothesis testing}
 \itemize{
@@ -83,7 +84,8 @@ two degrees of freedom (e.g. anova)
 \itemize{
 \item \code{effectsize}: the name of the effect size
 \item \code{estimate}: estimated value of the effect size
-\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.level}: the coverage level of the confidence/credible interval
+(e.g. \code{0.95}); the interval itself spans \code{conf.low} to \code{conf.high}
 \item \code{conf.low}: lower bound for the effect size estimate
 \item \code{conf.high}: upper bound for the effect size estimate
 \item \code{conf.method}: method used to compute the confidence/credible interval
@@ -93,28 +95,31 @@ two degrees of freedom (e.g. anova)
 \strong{Bayesian analysis} (only when \code{type = "bayes"})
 \itemize{
 \item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
-\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor (present for most, but
+not all, Bayesian analyses)
 \item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
 used to compute the Bayes factor and posterior estimates
 }
 
-\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\strong{Pairwise comparisons} (for \code{pairwise_comparisons()} and
 \code{pairwise_contingency_table()})
 \itemize{
 \item \code{group1}, \code{group2}: the two levels being compared
-\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
-\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+\item \code{p.adjust.method}: the adjustment method used for multiple comparisons
+\item \code{p.value.adj}: the adjusted \emph{p}-value; returned by
+\code{pairwise_contingency_table()}. Note that \code{pairwise_comparisons()} instead
+folds the adjusted value into \code{p.value} (and does not return a separate
+\code{p.value.adj} column)
 }
 
 \strong{Common columns}
 \itemize{
 \item \code{n.obs}: number of observations
-\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
-expression (a \code{language} object, not a character string) containing the
+\item \code{expression}: a list-column of pre-formatted
+\href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath} expressions; each
+element is a \code{language} object (not a character string) containing the
 statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
 \code{annotate()})
-\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
-group name and its sample size, useful as an axis or facet label
 }
 
 For a per-function, column-by-column breakdown of the output (and an explanation

--- a/man/corr_test.Rd
+++ b/man/corr_test.Rd
@@ -63,7 +63,12 @@ value corresponds to scale for fixed effects.}
 \item{...}{Additional arguments (currently ignored).}
 }
 \value{
-The returned tibble data frame can contain some or all of the following columns (the exact columns will depend on the statistical test):
+The returned object is a tibble data frame with the additional class
+\code{"statsExpressions"}. The exact set of columns depends on the statistical test
+and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
+any given call returns \emph{some} (not all) of the columns below.
+
+\strong{Hypothesis testing}
 \itemize{
 \item \code{statistic}: the numeric value of a statistic
 \item \code{df}: the numeric value of a parameter being modeled (often degrees
@@ -72,18 +77,50 @@ of freedom for the test)
 two degrees of freedom (e.g. anova)
 \item \code{p.value}: the two-sided \emph{p}-value associated with the observed statistic
 \item \code{method}: the name of the inferential statistical test
-\item \code{estimate}: estimated value of the effect size
-\item \code{conf.low}: lower bound for the effect size estimate
-\item \code{conf.high}: upper bound for the effect size estimate
-\item \code{conf.level}: width of the confidence interval
-\item \code{conf.method}: method used to compute confidence interval
-\item \code{conf.distribution}: statistical distribution for the effect
-\item \code{effectsize}: the name of the effect size
-\item \code{n.obs}: number of observations
-\item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+\strong{Effect size estimation}
+\itemize{
+\item \code{effectsize}: the name of the effect size
+\item \code{estimate}: estimated value of the effect size
+\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.low}: lower bound for the effect size estimate
+\item \code{conf.high}: upper bound for the effect size estimate
+\item \code{conf.method}: method used to compute the confidence/credible interval
+\item \code{conf.distribution}: statistical distribution for the effect
+}
+
+\strong{Bayesian analysis} (only when \code{type = "bayes"})
+\itemize{
+\item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
+used to compute the Bayes factor and posterior estimates
+}
+
+\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\code{pairwise_contingency_table()})
+\itemize{
+\item \code{group1}, \code{group2}: the two levels being compared
+\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
+\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+}
+
+\strong{Common columns}
+\itemize{
+\item \code{n.obs}: number of observations
+\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
+expression (a \code{language} object, not a character string) containing the
+statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
+\code{annotate()})
+\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
+group name and its sample size, useful as an axis or facet label
+}
+
+For a per-function, column-by-column breakdown of the output (and an explanation
+of the internal \code{add_expression_col()} engine that builds the \code{expression}
+column), see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html}{Return value schema}
+article. For more examples, see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric, non-parametric, robust, and Bayesian correlation test.

--- a/man/meta_analysis.Rd
+++ b/man/meta_analysis.Rd
@@ -52,7 +52,12 @@ will be computed.}
 function.}
 }
 \value{
-The returned tibble data frame can contain some or all of the following columns (the exact columns will depend on the statistical test):
+The returned object is a tibble data frame with the additional class
+\code{"statsExpressions"}. The exact set of columns depends on the statistical test
+and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
+any given call returns \emph{some} (not all) of the columns below.
+
+\strong{Hypothesis testing}
 \itemize{
 \item \code{statistic}: the numeric value of a statistic
 \item \code{df}: the numeric value of a parameter being modeled (often degrees
@@ -61,18 +66,50 @@ of freedom for the test)
 two degrees of freedom (e.g. anova)
 \item \code{p.value}: the two-sided \emph{p}-value associated with the observed statistic
 \item \code{method}: the name of the inferential statistical test
-\item \code{estimate}: estimated value of the effect size
-\item \code{conf.low}: lower bound for the effect size estimate
-\item \code{conf.high}: upper bound for the effect size estimate
-\item \code{conf.level}: width of the confidence interval
-\item \code{conf.method}: method used to compute confidence interval
-\item \code{conf.distribution}: statistical distribution for the effect
-\item \code{effectsize}: the name of the effect size
-\item \code{n.obs}: number of observations
-\item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+\strong{Effect size estimation}
+\itemize{
+\item \code{effectsize}: the name of the effect size
+\item \code{estimate}: estimated value of the effect size
+\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.low}: lower bound for the effect size estimate
+\item \code{conf.high}: upper bound for the effect size estimate
+\item \code{conf.method}: method used to compute the confidence/credible interval
+\item \code{conf.distribution}: statistical distribution for the effect
+}
+
+\strong{Bayesian analysis} (only when \code{type = "bayes"})
+\itemize{
+\item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
+used to compute the Bayes factor and posterior estimates
+}
+
+\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\code{pairwise_contingency_table()})
+\itemize{
+\item \code{group1}, \code{group2}: the two levels being compared
+\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
+\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+}
+
+\strong{Common columns}
+\itemize{
+\item \code{n.obs}: number of observations
+\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
+expression (a \code{language} object, not a character string) containing the
+statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
+\code{annotate()})
+\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
+group name and its sample size, useful as an axis or facet label
+}
+
+For a per-function, column-by-column breakdown of the output (and an explanation
+of the internal \code{add_expression_col()} engine that builds the \code{expression}
+column), see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html}{Return value schema}
+article. For more examples, see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric, non-parametric, robust, and Bayesian random-effects meta-analysis.

--- a/man/meta_analysis.Rd
+++ b/man/meta_analysis.Rd
@@ -53,9 +53,10 @@ function.}
 }
 \value{
 The returned object is a tibble data frame with the additional class
-\code{"statsExpressions"}. The exact set of columns depends on the statistical test
-and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
-any given call returns \emph{some} (not all) of the columns below.
+\code{"statsExpressions"}. The exact set of columns depends on the test and, for
+functions that accept a \code{type} argument, on the chosen analysis (parametric,
+non-parametric, robust, or Bayesian). Any given call therefore returns \emph{some}
+(not all) of the columns below.
 
 \strong{Hypothesis testing}
 \itemize{
@@ -72,7 +73,8 @@ two degrees of freedom (e.g. anova)
 \itemize{
 \item \code{effectsize}: the name of the effect size
 \item \code{estimate}: estimated value of the effect size
-\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.level}: the coverage level of the confidence/credible interval
+(e.g. \code{0.95}); the interval itself spans \code{conf.low} to \code{conf.high}
 \item \code{conf.low}: lower bound for the effect size estimate
 \item \code{conf.high}: upper bound for the effect size estimate
 \item \code{conf.method}: method used to compute the confidence/credible interval
@@ -82,28 +84,31 @@ two degrees of freedom (e.g. anova)
 \strong{Bayesian analysis} (only when \code{type = "bayes"})
 \itemize{
 \item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
-\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor (present for most, but
+not all, Bayesian analyses)
 \item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
 used to compute the Bayes factor and posterior estimates
 }
 
-\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\strong{Pairwise comparisons} (for \code{pairwise_comparisons()} and
 \code{pairwise_contingency_table()})
 \itemize{
 \item \code{group1}, \code{group2}: the two levels being compared
-\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
-\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+\item \code{p.adjust.method}: the adjustment method used for multiple comparisons
+\item \code{p.value.adj}: the adjusted \emph{p}-value; returned by
+\code{pairwise_contingency_table()}. Note that \code{pairwise_comparisons()} instead
+folds the adjusted value into \code{p.value} (and does not return a separate
+\code{p.value.adj} column)
 }
 
 \strong{Common columns}
 \itemize{
 \item \code{n.obs}: number of observations
-\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
-expression (a \code{language} object, not a character string) containing the
+\item \code{expression}: a list-column of pre-formatted
+\href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath} expressions; each
+element is a \code{language} object (not a character string) containing the
 statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
 \code{annotate()})
-\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
-group name and its sample size, useful as an axis or facet label
 }
 
 For a per-function, column-by-column breakdown of the output (and an explanation

--- a/man/one_sample_test.Rd
+++ b/man/one_sample_test.Rd
@@ -77,9 +77,10 @@ Relevant only when \code{type = "nonparametric"} (Default: \code{FALSE}).}
 }
 \value{
 The returned object is a tibble data frame with the additional class
-\code{"statsExpressions"}. The exact set of columns depends on the statistical test
-and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
-any given call returns \emph{some} (not all) of the columns below.
+\code{"statsExpressions"}. The exact set of columns depends on the test and, for
+functions that accept a \code{type} argument, on the chosen analysis (parametric,
+non-parametric, robust, or Bayesian). Any given call therefore returns \emph{some}
+(not all) of the columns below.
 
 \strong{Hypothesis testing}
 \itemize{
@@ -96,7 +97,8 @@ two degrees of freedom (e.g. anova)
 \itemize{
 \item \code{effectsize}: the name of the effect size
 \item \code{estimate}: estimated value of the effect size
-\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.level}: the coverage level of the confidence/credible interval
+(e.g. \code{0.95}); the interval itself spans \code{conf.low} to \code{conf.high}
 \item \code{conf.low}: lower bound for the effect size estimate
 \item \code{conf.high}: upper bound for the effect size estimate
 \item \code{conf.method}: method used to compute the confidence/credible interval
@@ -106,28 +108,31 @@ two degrees of freedom (e.g. anova)
 \strong{Bayesian analysis} (only when \code{type = "bayes"})
 \itemize{
 \item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
-\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor (present for most, but
+not all, Bayesian analyses)
 \item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
 used to compute the Bayes factor and posterior estimates
 }
 
-\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\strong{Pairwise comparisons} (for \code{pairwise_comparisons()} and
 \code{pairwise_contingency_table()})
 \itemize{
 \item \code{group1}, \code{group2}: the two levels being compared
-\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
-\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+\item \code{p.adjust.method}: the adjustment method used for multiple comparisons
+\item \code{p.value.adj}: the adjusted \emph{p}-value; returned by
+\code{pairwise_contingency_table()}. Note that \code{pairwise_comparisons()} instead
+folds the adjusted value into \code{p.value} (and does not return a separate
+\code{p.value.adj} column)
 }
 
 \strong{Common columns}
 \itemize{
 \item \code{n.obs}: number of observations
-\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
-expression (a \code{language} object, not a character string) containing the
+\item \code{expression}: a list-column of pre-formatted
+\href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath} expressions; each
+element is a \code{language} object (not a character string) containing the
 statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
 \code{annotate()})
-\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
-group name and its sample size, useful as an axis or facet label
 }
 
 For a per-function, column-by-column breakdown of the output (and an explanation

--- a/man/one_sample_test.Rd
+++ b/man/one_sample_test.Rd
@@ -76,7 +76,12 @@ Relevant only when \code{type = "nonparametric"} (Default: \code{FALSE}).}
 \item{...}{Currently ignored.}
 }
 \value{
-The returned tibble data frame can contain some or all of the following columns (the exact columns will depend on the statistical test):
+The returned object is a tibble data frame with the additional class
+\code{"statsExpressions"}. The exact set of columns depends on the statistical test
+and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
+any given call returns \emph{some} (not all) of the columns below.
+
+\strong{Hypothesis testing}
 \itemize{
 \item \code{statistic}: the numeric value of a statistic
 \item \code{df}: the numeric value of a parameter being modeled (often degrees
@@ -85,18 +90,50 @@ of freedom for the test)
 two degrees of freedom (e.g. anova)
 \item \code{p.value}: the two-sided \emph{p}-value associated with the observed statistic
 \item \code{method}: the name of the inferential statistical test
-\item \code{estimate}: estimated value of the effect size
-\item \code{conf.low}: lower bound for the effect size estimate
-\item \code{conf.high}: upper bound for the effect size estimate
-\item \code{conf.level}: width of the confidence interval
-\item \code{conf.method}: method used to compute confidence interval
-\item \code{conf.distribution}: statistical distribution for the effect
-\item \code{effectsize}: the name of the effect size
-\item \code{n.obs}: number of observations
-\item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+\strong{Effect size estimation}
+\itemize{
+\item \code{effectsize}: the name of the effect size
+\item \code{estimate}: estimated value of the effect size
+\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.low}: lower bound for the effect size estimate
+\item \code{conf.high}: upper bound for the effect size estimate
+\item \code{conf.method}: method used to compute the confidence/credible interval
+\item \code{conf.distribution}: statistical distribution for the effect
+}
+
+\strong{Bayesian analysis} (only when \code{type = "bayes"})
+\itemize{
+\item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
+used to compute the Bayes factor and posterior estimates
+}
+
+\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\code{pairwise_contingency_table()})
+\itemize{
+\item \code{group1}, \code{group2}: the two levels being compared
+\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
+\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+}
+
+\strong{Common columns}
+\itemize{
+\item \code{n.obs}: number of observations
+\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
+expression (a \code{language} object, not a character string) containing the
+statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
+\code{annotate()})
+\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
+group name and its sample size, useful as an axis or facet label
+}
+
+For a per-function, column-by-column breakdown of the output (and an explanation
+of the internal \code{add_expression_col()} engine that builds the \code{expression}
+column), see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html}{Return value schema}
+article. For more examples, see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric, non-parametric, robust, and Bayesian one-sample tests.

--- a/man/oneway_anova.Rd
+++ b/man/oneway_anova.Rd
@@ -99,9 +99,10 @@ for the effect size (Default: \code{100L}).}
 }
 \value{
 The returned object is a tibble data frame with the additional class
-\code{"statsExpressions"}. The exact set of columns depends on the statistical test
-and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
-any given call returns \emph{some} (not all) of the columns below.
+\code{"statsExpressions"}. The exact set of columns depends on the test and, for
+functions that accept a \code{type} argument, on the chosen analysis (parametric,
+non-parametric, robust, or Bayesian). Any given call therefore returns \emph{some}
+(not all) of the columns below.
 
 \strong{Hypothesis testing}
 \itemize{
@@ -118,7 +119,8 @@ two degrees of freedom (e.g. anova)
 \itemize{
 \item \code{effectsize}: the name of the effect size
 \item \code{estimate}: estimated value of the effect size
-\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.level}: the coverage level of the confidence/credible interval
+(e.g. \code{0.95}); the interval itself spans \code{conf.low} to \code{conf.high}
 \item \code{conf.low}: lower bound for the effect size estimate
 \item \code{conf.high}: upper bound for the effect size estimate
 \item \code{conf.method}: method used to compute the confidence/credible interval
@@ -128,28 +130,31 @@ two degrees of freedom (e.g. anova)
 \strong{Bayesian analysis} (only when \code{type = "bayes"})
 \itemize{
 \item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
-\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor (present for most, but
+not all, Bayesian analyses)
 \item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
 used to compute the Bayes factor and posterior estimates
 }
 
-\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\strong{Pairwise comparisons} (for \code{pairwise_comparisons()} and
 \code{pairwise_contingency_table()})
 \itemize{
 \item \code{group1}, \code{group2}: the two levels being compared
-\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
-\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+\item \code{p.adjust.method}: the adjustment method used for multiple comparisons
+\item \code{p.value.adj}: the adjusted \emph{p}-value; returned by
+\code{pairwise_contingency_table()}. Note that \code{pairwise_comparisons()} instead
+folds the adjusted value into \code{p.value} (and does not return a separate
+\code{p.value.adj} column)
 }
 
 \strong{Common columns}
 \itemize{
 \item \code{n.obs}: number of observations
-\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
-expression (a \code{language} object, not a character string) containing the
+\item \code{expression}: a list-column of pre-formatted
+\href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath} expressions; each
+element is a \code{language} object (not a character string) containing the
 statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
 \code{annotate()})
-\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
-group name and its sample size, useful as an axis or facet label
 }
 
 For a per-function, column-by-column breakdown of the output (and an explanation

--- a/man/oneway_anova.Rd
+++ b/man/oneway_anova.Rd
@@ -98,7 +98,12 @@ for the effect size (Default: \code{100L}).}
 \item{...}{Additional arguments (currently ignored).}
 }
 \value{
-The returned tibble data frame can contain some or all of the following columns (the exact columns will depend on the statistical test):
+The returned object is a tibble data frame with the additional class
+\code{"statsExpressions"}. The exact set of columns depends on the statistical test
+and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
+any given call returns \emph{some} (not all) of the columns below.
+
+\strong{Hypothesis testing}
 \itemize{
 \item \code{statistic}: the numeric value of a statistic
 \item \code{df}: the numeric value of a parameter being modeled (often degrees
@@ -107,18 +112,50 @@ of freedom for the test)
 two degrees of freedom (e.g. anova)
 \item \code{p.value}: the two-sided \emph{p}-value associated with the observed statistic
 \item \code{method}: the name of the inferential statistical test
-\item \code{estimate}: estimated value of the effect size
-\item \code{conf.low}: lower bound for the effect size estimate
-\item \code{conf.high}: upper bound for the effect size estimate
-\item \code{conf.level}: width of the confidence interval
-\item \code{conf.method}: method used to compute confidence interval
-\item \code{conf.distribution}: statistical distribution for the effect
-\item \code{effectsize}: the name of the effect size
-\item \code{n.obs}: number of observations
-\item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+\strong{Effect size estimation}
+\itemize{
+\item \code{effectsize}: the name of the effect size
+\item \code{estimate}: estimated value of the effect size
+\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.low}: lower bound for the effect size estimate
+\item \code{conf.high}: upper bound for the effect size estimate
+\item \code{conf.method}: method used to compute the confidence/credible interval
+\item \code{conf.distribution}: statistical distribution for the effect
+}
+
+\strong{Bayesian analysis} (only when \code{type = "bayes"})
+\itemize{
+\item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
+used to compute the Bayes factor and posterior estimates
+}
+
+\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\code{pairwise_contingency_table()})
+\itemize{
+\item \code{group1}, \code{group2}: the two levels being compared
+\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
+\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+}
+
+\strong{Common columns}
+\itemize{
+\item \code{n.obs}: number of observations
+\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
+expression (a \code{language} object, not a character string) containing the
+statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
+\code{annotate()})
+\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
+group name and its sample size, useful as an axis or facet label
+}
+
+For a per-function, column-by-column breakdown of the output (and an explanation
+of the internal \code{add_expression_col()} engine that builds the \code{expression}
+column), see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html}{Return value schema}
+article. For more examples, see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric, non-parametric, robust, and Bayesian one-way ANOVA.

--- a/man/pairwise_comparisons.Rd
+++ b/man/pairwise_comparisons.Rd
@@ -94,9 +94,10 @@ Relevant only when \code{type = "nonparametric"} (Default: \code{FALSE}).}
 }
 \value{
 The returned object is a tibble data frame with the additional class
-\code{"statsExpressions"}. The exact set of columns depends on the statistical test
-and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
-any given call returns \emph{some} (not all) of the columns below.
+\code{"statsExpressions"}. The exact set of columns depends on the test and, for
+functions that accept a \code{type} argument, on the chosen analysis (parametric,
+non-parametric, robust, or Bayesian). Any given call therefore returns \emph{some}
+(not all) of the columns below.
 
 \strong{Hypothesis testing}
 \itemize{
@@ -113,7 +114,8 @@ two degrees of freedom (e.g. anova)
 \itemize{
 \item \code{effectsize}: the name of the effect size
 \item \code{estimate}: estimated value of the effect size
-\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.level}: the coverage level of the confidence/credible interval
+(e.g. \code{0.95}); the interval itself spans \code{conf.low} to \code{conf.high}
 \item \code{conf.low}: lower bound for the effect size estimate
 \item \code{conf.high}: upper bound for the effect size estimate
 \item \code{conf.method}: method used to compute the confidence/credible interval
@@ -123,28 +125,31 @@ two degrees of freedom (e.g. anova)
 \strong{Bayesian analysis} (only when \code{type = "bayes"})
 \itemize{
 \item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
-\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor (present for most, but
+not all, Bayesian analyses)
 \item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
 used to compute the Bayes factor and posterior estimates
 }
 
-\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\strong{Pairwise comparisons} (for \code{pairwise_comparisons()} and
 \code{pairwise_contingency_table()})
 \itemize{
 \item \code{group1}, \code{group2}: the two levels being compared
-\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
-\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+\item \code{p.adjust.method}: the adjustment method used for multiple comparisons
+\item \code{p.value.adj}: the adjusted \emph{p}-value; returned by
+\code{pairwise_contingency_table()}. Note that \code{pairwise_comparisons()} instead
+folds the adjusted value into \code{p.value} (and does not return a separate
+\code{p.value.adj} column)
 }
 
 \strong{Common columns}
 \itemize{
 \item \code{n.obs}: number of observations
-\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
-expression (a \code{language} object, not a character string) containing the
+\item \code{expression}: a list-column of pre-formatted
+\href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath} expressions; each
+element is a \code{language} object (not a character string) containing the
 statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
 \code{annotate()})
-\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
-group name and its sample size, useful as an axis or facet label
 }
 
 For a per-function, column-by-column breakdown of the output (and an explanation

--- a/man/pairwise_comparisons.Rd
+++ b/man/pairwise_comparisons.Rd
@@ -93,7 +93,12 @@ Relevant only when \code{type = "nonparametric"} (Default: \code{FALSE}).}
 \item{...}{Additional arguments passed to other methods.}
 }
 \value{
-The returned tibble data frame can contain some or all of the following columns (the exact columns will depend on the statistical test):
+The returned object is a tibble data frame with the additional class
+\code{"statsExpressions"}. The exact set of columns depends on the statistical test
+and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
+any given call returns \emph{some} (not all) of the columns below.
+
+\strong{Hypothesis testing}
 \itemize{
 \item \code{statistic}: the numeric value of a statistic
 \item \code{df}: the numeric value of a parameter being modeled (often degrees
@@ -102,18 +107,50 @@ of freedom for the test)
 two degrees of freedom (e.g. anova)
 \item \code{p.value}: the two-sided \emph{p}-value associated with the observed statistic
 \item \code{method}: the name of the inferential statistical test
-\item \code{estimate}: estimated value of the effect size
-\item \code{conf.low}: lower bound for the effect size estimate
-\item \code{conf.high}: upper bound for the effect size estimate
-\item \code{conf.level}: width of the confidence interval
-\item \code{conf.method}: method used to compute confidence interval
-\item \code{conf.distribution}: statistical distribution for the effect
-\item \code{effectsize}: the name of the effect size
-\item \code{n.obs}: number of observations
-\item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+\strong{Effect size estimation}
+\itemize{
+\item \code{effectsize}: the name of the effect size
+\item \code{estimate}: estimated value of the effect size
+\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.low}: lower bound for the effect size estimate
+\item \code{conf.high}: upper bound for the effect size estimate
+\item \code{conf.method}: method used to compute the confidence/credible interval
+\item \code{conf.distribution}: statistical distribution for the effect
+}
+
+\strong{Bayesian analysis} (only when \code{type = "bayes"})
+\itemize{
+\item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
+used to compute the Bayes factor and posterior estimates
+}
+
+\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\code{pairwise_contingency_table()})
+\itemize{
+\item \code{group1}, \code{group2}: the two levels being compared
+\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
+\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+}
+
+\strong{Common columns}
+\itemize{
+\item \code{n.obs}: number of observations
+\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
+expression (a \code{language} object, not a character string) containing the
+statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
+\code{annotate()})
+\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
+group name and its sample size, useful as an axis or facet label
+}
+
+For a per-function, column-by-column breakdown of the output (and an explanation
+of the internal \code{add_expression_col()} engine that builds the \code{expression}
+column), see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html}{Return value schema}
+article. For more examples, see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Calculate parametric, non-parametric, robust, and Bayes Factor pairwise

--- a/man/pairwise_contingency_table.Rd
+++ b/man/pairwise_contingency_table.Rd
@@ -55,7 +55,12 @@ the \href{https://easystats.github.io/effectsize/}{effectsize_CIs vignette}.}
 \item{...}{Additional arguments (currently ignored).}
 }
 \value{
-The returned tibble data frame can contain some or all of the following columns (the exact columns will depend on the statistical test):
+The returned object is a tibble data frame with the additional class
+\code{"statsExpressions"}. The exact set of columns depends on the statistical test
+and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
+any given call returns \emph{some} (not all) of the columns below.
+
+\strong{Hypothesis testing}
 \itemize{
 \item \code{statistic}: the numeric value of a statistic
 \item \code{df}: the numeric value of a parameter being modeled (often degrees
@@ -64,18 +69,50 @@ of freedom for the test)
 two degrees of freedom (e.g. anova)
 \item \code{p.value}: the two-sided \emph{p}-value associated with the observed statistic
 \item \code{method}: the name of the inferential statistical test
-\item \code{estimate}: estimated value of the effect size
-\item \code{conf.low}: lower bound for the effect size estimate
-\item \code{conf.high}: upper bound for the effect size estimate
-\item \code{conf.level}: width of the confidence interval
-\item \code{conf.method}: method used to compute confidence interval
-\item \code{conf.distribution}: statistical distribution for the effect
-\item \code{effectsize}: the name of the effect size
-\item \code{n.obs}: number of observations
-\item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+\strong{Effect size estimation}
+\itemize{
+\item \code{effectsize}: the name of the effect size
+\item \code{estimate}: estimated value of the effect size
+\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.low}: lower bound for the effect size estimate
+\item \code{conf.high}: upper bound for the effect size estimate
+\item \code{conf.method}: method used to compute the confidence/credible interval
+\item \code{conf.distribution}: statistical distribution for the effect
+}
+
+\strong{Bayesian analysis} (only when \code{type = "bayes"})
+\itemize{
+\item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
+used to compute the Bayes factor and posterior estimates
+}
+
+\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\code{pairwise_contingency_table()})
+\itemize{
+\item \code{group1}, \code{group2}: the two levels being compared
+\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
+\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+}
+
+\strong{Common columns}
+\itemize{
+\item \code{n.obs}: number of observations
+\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
+expression (a \code{language} object, not a character string) containing the
+statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
+\code{annotate()})
+\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
+group name and its sample size, useful as an axis or facet label
+}
+
+For a per-function, column-by-column breakdown of the output (and an explanation
+of the internal \code{add_expression_col()} engine that builds the \code{expression}
+column), see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html}{Return value schema}
+article. For more examples, see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Pairwise Fisher's exact tests as post hoc tests for contingency table

--- a/man/pairwise_contingency_table.Rd
+++ b/man/pairwise_contingency_table.Rd
@@ -56,9 +56,10 @@ the \href{https://easystats.github.io/effectsize/}{effectsize_CIs vignette}.}
 }
 \value{
 The returned object is a tibble data frame with the additional class
-\code{"statsExpressions"}. The exact set of columns depends on the statistical test
-and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
-any given call returns \emph{some} (not all) of the columns below.
+\code{"statsExpressions"}. The exact set of columns depends on the test and, for
+functions that accept a \code{type} argument, on the chosen analysis (parametric,
+non-parametric, robust, or Bayesian). Any given call therefore returns \emph{some}
+(not all) of the columns below.
 
 \strong{Hypothesis testing}
 \itemize{
@@ -75,7 +76,8 @@ two degrees of freedom (e.g. anova)
 \itemize{
 \item \code{effectsize}: the name of the effect size
 \item \code{estimate}: estimated value of the effect size
-\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.level}: the coverage level of the confidence/credible interval
+(e.g. \code{0.95}); the interval itself spans \code{conf.low} to \code{conf.high}
 \item \code{conf.low}: lower bound for the effect size estimate
 \item \code{conf.high}: upper bound for the effect size estimate
 \item \code{conf.method}: method used to compute the confidence/credible interval
@@ -85,28 +87,31 @@ two degrees of freedom (e.g. anova)
 \strong{Bayesian analysis} (only when \code{type = "bayes"})
 \itemize{
 \item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
-\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor (present for most, but
+not all, Bayesian analyses)
 \item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
 used to compute the Bayes factor and posterior estimates
 }
 
-\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\strong{Pairwise comparisons} (for \code{pairwise_comparisons()} and
 \code{pairwise_contingency_table()})
 \itemize{
 \item \code{group1}, \code{group2}: the two levels being compared
-\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
-\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+\item \code{p.adjust.method}: the adjustment method used for multiple comparisons
+\item \code{p.value.adj}: the adjusted \emph{p}-value; returned by
+\code{pairwise_contingency_table()}. Note that \code{pairwise_comparisons()} instead
+folds the adjusted value into \code{p.value} (and does not return a separate
+\code{p.value.adj} column)
 }
 
 \strong{Common columns}
 \itemize{
 \item \code{n.obs}: number of observations
-\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
-expression (a \code{language} object, not a character string) containing the
+\item \code{expression}: a list-column of pre-formatted
+\href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath} expressions; each
+element is a \code{language} object (not a character string) containing the
 statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
 \code{annotate()})
-\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
-group name and its sample size, useful as an axis or facet label
 }
 
 For a per-function, column-by-column breakdown of the output (and an explanation

--- a/man/rmd-fragments/return.Rmd
+++ b/man/rmd-fragments/return.Rmd
@@ -1,4 +1,9 @@
-The returned tibble data frame can contain some or all of the following columns (the exact columns will depend on the statistical test):
+The returned object is a tibble data frame with the additional class
+`"statsExpressions"`. The exact set of columns depends on the statistical test
+and the `type` of analysis (parametric, non-parametric, robust, or Bayesian), so
+any given call returns *some* (not all) of the columns below.
+
+**Hypothesis testing**
 
   - `statistic`: the numeric value of a statistic
 
@@ -9,25 +14,56 @@ The returned tibble data frame can contain some or all of the following columns 
     two degrees of freedom (e.g. anova)
 
   - `p.value`: the two-sided *p*-value associated with the observed statistic
-  
+
   - `method`: the name of the inferential statistical test
 
+**Effect size estimation**
+
+  - `effectsize`: the name of the effect size
+
   - `estimate`: estimated value of the effect size
+
+  - `conf.level`: width of the confidence/credible interval
 
   - `conf.low`: lower bound for the effect size estimate
 
   - `conf.high`: upper bound for the effect size estimate
-  
-  - `conf.level`: width of the confidence interval
-  
-  - `conf.method`: method used to compute confidence interval
-  
+
+  - `conf.method`: method used to compute the confidence/credible interval
+
   - `conf.distribution`: statistical distribution for the effect
-  
-  - `effectsize`: the name of the effect size
+
+**Bayesian analysis** (only when `type = "bayes"`)
+
+  - `bf10`: Bayes factor for the alternative hypothesis relative to the null
+
+  - `log_e_bf10`: natural logarithm of the Bayes factor
+
+  - `prior.distribution`, `prior.scale`, `prior.location`: prior specification
+    used to compute the Bayes factor and posterior estimates
+
+**Pairwise comparisons** (only for `pairwise_comparisons()` and
+`pairwise_contingency_table()`)
+
+  - `group1`, `group2`: the two levels being compared
+
+  - `p.value.adj`: the *p*-value adjusted for multiple comparisons
+
+  - `p.adjust.method`: the adjustment method used for the *p*-value
+
+**Common columns**
 
   - `n.obs`: number of observations
-  
-  - `expression`: pre-formatted expression containing statistical details
 
-For examples, see [data frame output vignette](https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html).
+  - `expression`: a pre-formatted [plotmath](https://rdrr.io/r/grDevices/plotmath.html)
+    expression (a `language` object, not a character string) containing the
+    statistical details, ready to be used in `{ggplot2}` (e.g. in `labs()` or
+    `annotate()`)
+
+  - `n.expression`: (only for `centrality_description()`) a label combining the
+    group name and its sample size, useful as an axis or facet label
+
+For a per-function, column-by-column breakdown of the output (and an explanation
+of the internal `add_expression_col()` engine that builds the `expression`
+column), see the [Return value schema](https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html)
+article. For more examples, see the [data frame output vignette](https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html).

--- a/man/rmd-fragments/return.Rmd
+++ b/man/rmd-fragments/return.Rmd
@@ -1,7 +1,8 @@
 The returned object is a tibble data frame with the additional class
-`"statsExpressions"`. The exact set of columns depends on the statistical test
-and the `type` of analysis (parametric, non-parametric, robust, or Bayesian), so
-any given call returns *some* (not all) of the columns below.
+`"statsExpressions"`. The exact set of columns depends on the test and, for
+functions that accept a `type` argument, on the chosen analysis (parametric,
+non-parametric, robust, or Bayesian). Any given call therefore returns *some*
+(not all) of the columns below.
 
 **Hypothesis testing**
 
@@ -23,7 +24,8 @@ any given call returns *some* (not all) of the columns below.
 
   - `estimate`: estimated value of the effect size
 
-  - `conf.level`: width of the confidence/credible interval
+  - `conf.level`: the coverage level of the confidence/credible interval
+    (e.g. `0.95`); the interval itself spans `conf.low` to `conf.high`
 
   - `conf.low`: lower bound for the effect size estimate
 
@@ -37,31 +39,33 @@ any given call returns *some* (not all) of the columns below.
 
   - `bf10`: Bayes factor for the alternative hypothesis relative to the null
 
-  - `log_e_bf10`: natural logarithm of the Bayes factor
+  - `log_e_bf10`: natural logarithm of the Bayes factor (present for most, but
+    not all, Bayesian analyses)
 
   - `prior.distribution`, `prior.scale`, `prior.location`: prior specification
     used to compute the Bayes factor and posterior estimates
 
-**Pairwise comparisons** (only for `pairwise_comparisons()` and
+**Pairwise comparisons** (for `pairwise_comparisons()` and
 `pairwise_contingency_table()`)
 
   - `group1`, `group2`: the two levels being compared
 
-  - `p.value.adj`: the *p*-value adjusted for multiple comparisons
+  - `p.adjust.method`: the adjustment method used for multiple comparisons
 
-  - `p.adjust.method`: the adjustment method used for the *p*-value
+  - `p.value.adj`: the adjusted *p*-value; returned by
+    `pairwise_contingency_table()`. Note that `pairwise_comparisons()` instead
+    folds the adjusted value into `p.value` (and does not return a separate
+    `p.value.adj` column)
 
 **Common columns**
 
   - `n.obs`: number of observations
 
-  - `expression`: a pre-formatted [plotmath](https://rdrr.io/r/grDevices/plotmath.html)
-    expression (a `language` object, not a character string) containing the
+  - `expression`: a list-column of pre-formatted
+    [plotmath](https://rdrr.io/r/grDevices/plotmath.html) expressions; each
+    element is a `language` object (not a character string) containing the
     statistical details, ready to be used in `{ggplot2}` (e.g. in `labs()` or
     `annotate()`)
-
-  - `n.expression`: (only for `centrality_description()`) a label combining the
-    group name and its sample size, useful as an axis or facet label
 
 For a per-function, column-by-column breakdown of the output (and an explanation
 of the internal `add_expression_col()` engine that builds the `expression`

--- a/man/rmd-fragments/return_centrality.Rmd
+++ b/man/rmd-fragments/return_centrality.Rmd
@@ -1,0 +1,43 @@
+The returned object is a tibble data frame with the additional class
+`"statsExpressions"`. Unlike the hypothesis-testing functions, this one returns
+one row **per level** of the grouping variable `x`, describing the distribution
+of `y` within that level. The columns are:
+
+  - the grouping variable (named after `x`, e.g. `Species`)
+
+  - the requested centrality estimate (named after `y`, e.g. `Sepal.Length`):
+    the mean (`type = "parametric"`), median (`"nonparametric"`), trimmed mean
+    (`"robust"`), or MAP estimate (`"bayes"`)
+
+  - `std.dev`: standard deviation (for `"parametric"` and `"robust"`)
+
+  - `mad`: median absolute deviation (for `"nonparametric"`)
+
+  - `iqr`: interquartile range
+
+  - `conf.low`, `conf.high`: bounds of the confidence/credible interval for the
+    centrality estimate
+
+  - `min`, `max`: minimum and maximum values
+
+  - `skewness`, `kurtosis`: shape statistics of the distribution
+
+  - `n.obs`: number of non-missing observations
+
+  - `missing.obs`: number of missing observations
+
+  - `expression`: a list-column of pre-formatted
+    [plotmath](https://rdrr.io/r/grDevices/plotmath.html) expressions (each
+    element is a `language` object, not a character string) containing the
+    centrality estimate, ready to be used in `{ggplot2}`
+
+  - `n.expression`: a label combining the group name and its sample size (e.g.
+    `"setosa\n(n = 50)"`), useful as an axis or facet label
+
+The exact dispersion column depends on the `type` of analysis (`std.dev` vs
+`mad`), and `datawizard::describe_distribution()` is used internally to compute
+these indices.
+
+For more examples, see the [data frame output vignette](https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html)
+and the [Return value schema](https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html)
+article.

--- a/man/two_sample_test.Rd
+++ b/man/two_sample_test.Rd
@@ -108,9 +108,10 @@ Relevant only when \code{type = "nonparametric"} (Default: \code{FALSE}).}
 }
 \value{
 The returned object is a tibble data frame with the additional class
-\code{"statsExpressions"}. The exact set of columns depends on the statistical test
-and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
-any given call returns \emph{some} (not all) of the columns below.
+\code{"statsExpressions"}. The exact set of columns depends on the test and, for
+functions that accept a \code{type} argument, on the chosen analysis (parametric,
+non-parametric, robust, or Bayesian). Any given call therefore returns \emph{some}
+(not all) of the columns below.
 
 \strong{Hypothesis testing}
 \itemize{
@@ -127,7 +128,8 @@ two degrees of freedom (e.g. anova)
 \itemize{
 \item \code{effectsize}: the name of the effect size
 \item \code{estimate}: estimated value of the effect size
-\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.level}: the coverage level of the confidence/credible interval
+(e.g. \code{0.95}); the interval itself spans \code{conf.low} to \code{conf.high}
 \item \code{conf.low}: lower bound for the effect size estimate
 \item \code{conf.high}: upper bound for the effect size estimate
 \item \code{conf.method}: method used to compute the confidence/credible interval
@@ -137,28 +139,31 @@ two degrees of freedom (e.g. anova)
 \strong{Bayesian analysis} (only when \code{type = "bayes"})
 \itemize{
 \item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
-\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor (present for most, but
+not all, Bayesian analyses)
 \item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
 used to compute the Bayes factor and posterior estimates
 }
 
-\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\strong{Pairwise comparisons} (for \code{pairwise_comparisons()} and
 \code{pairwise_contingency_table()})
 \itemize{
 \item \code{group1}, \code{group2}: the two levels being compared
-\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
-\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+\item \code{p.adjust.method}: the adjustment method used for multiple comparisons
+\item \code{p.value.adj}: the adjusted \emph{p}-value; returned by
+\code{pairwise_contingency_table()}. Note that \code{pairwise_comparisons()} instead
+folds the adjusted value into \code{p.value} (and does not return a separate
+\code{p.value.adj} column)
 }
 
 \strong{Common columns}
 \itemize{
 \item \code{n.obs}: number of observations
-\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
-expression (a \code{language} object, not a character string) containing the
+\item \code{expression}: a list-column of pre-formatted
+\href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath} expressions; each
+element is a \code{language} object (not a character string) containing the
 statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
 \code{annotate()})
-\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
-group name and its sample size, useful as an axis or facet label
 }
 
 For a per-function, column-by-column breakdown of the output (and an explanation

--- a/man/two_sample_test.Rd
+++ b/man/two_sample_test.Rd
@@ -107,7 +107,12 @@ Relevant only when \code{type = "nonparametric"} (Default: \code{FALSE}).}
 \item{...}{Currently ignored.}
 }
 \value{
-The returned tibble data frame can contain some or all of the following columns (the exact columns will depend on the statistical test):
+The returned object is a tibble data frame with the additional class
+\code{"statsExpressions"}. The exact set of columns depends on the statistical test
+and the \code{type} of analysis (parametric, non-parametric, robust, or Bayesian), so
+any given call returns \emph{some} (not all) of the columns below.
+
+\strong{Hypothesis testing}
 \itemize{
 \item \code{statistic}: the numeric value of a statistic
 \item \code{df}: the numeric value of a parameter being modeled (often degrees
@@ -116,18 +121,50 @@ of freedom for the test)
 two degrees of freedom (e.g. anova)
 \item \code{p.value}: the two-sided \emph{p}-value associated with the observed statistic
 \item \code{method}: the name of the inferential statistical test
-\item \code{estimate}: estimated value of the effect size
-\item \code{conf.low}: lower bound for the effect size estimate
-\item \code{conf.high}: upper bound for the effect size estimate
-\item \code{conf.level}: width of the confidence interval
-\item \code{conf.method}: method used to compute confidence interval
-\item \code{conf.distribution}: statistical distribution for the effect
-\item \code{effectsize}: the name of the effect size
-\item \code{n.obs}: number of observations
-\item \code{expression}: pre-formatted expression containing statistical details
 }
 
-For examples, see \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
+\strong{Effect size estimation}
+\itemize{
+\item \code{effectsize}: the name of the effect size
+\item \code{estimate}: estimated value of the effect size
+\item \code{conf.level}: width of the confidence/credible interval
+\item \code{conf.low}: lower bound for the effect size estimate
+\item \code{conf.high}: upper bound for the effect size estimate
+\item \code{conf.method}: method used to compute the confidence/credible interval
+\item \code{conf.distribution}: statistical distribution for the effect
+}
+
+\strong{Bayesian analysis} (only when \code{type = "bayes"})
+\itemize{
+\item \code{bf10}: Bayes factor for the alternative hypothesis relative to the null
+\item \code{log_e_bf10}: natural logarithm of the Bayes factor
+\item \code{prior.distribution}, \code{prior.scale}, \code{prior.location}: prior specification
+used to compute the Bayes factor and posterior estimates
+}
+
+\strong{Pairwise comparisons} (only for \code{pairwise_comparisons()} and
+\code{pairwise_contingency_table()})
+\itemize{
+\item \code{group1}, \code{group2}: the two levels being compared
+\item \code{p.value.adj}: the \emph{p}-value adjusted for multiple comparisons
+\item \code{p.adjust.method}: the adjustment method used for the \emph{p}-value
+}
+
+\strong{Common columns}
+\itemize{
+\item \code{n.obs}: number of observations
+\item \code{expression}: a pre-formatted \href{https://rdrr.io/r/grDevices/plotmath.html}{plotmath}
+expression (a \code{language} object, not a character string) containing the
+statistical details, ready to be used in \code{{ggplot2}} (e.g. in \code{labs()} or
+\code{annotate()})
+\item \code{n.expression}: (only for \code{centrality_description()}) a label combining the
+group name and its sample size, useful as an axis or facet label
+}
+
+For a per-function, column-by-column breakdown of the output (and an explanation
+of the internal \code{add_expression_col()} engine that builds the \code{expression}
+column), see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/return_value_schema.html}{Return value schema}
+article. For more examples, see the \href{https://www.indrapatil.com/statsExpressions/articles/web_only/dataframe_outputs.html}{data frame output vignette}.
 }
 \description{
 Parametric, non-parametric, robust, and Bayesian two-sample tests.

--- a/vignettes/web_only/return_value_schema.Rmd
+++ b/vignettes/web_only/return_value_schema.Rmd
@@ -145,15 +145,15 @@ set.seed(123)
 one_sample_test(mtcars, wt, test.value = 3, type = "bayes") |> dplyr::glimpse()
 ```
 
-| Column | Description |
-| :----- | :---------- |
-| `mu` | the null value the mean is tested against (`test.value`) |
-| `statistic`, `df.error`, `p.value` | test statistic, its degrees of freedom, and *p*-value (non-Bayesian) |
-| `effectsize`, `estimate` | name and value of the effect size (e.g. Hedges' *g*) |
-| `conf.level`, `conf.low`, `conf.high`, `conf.method`, `conf.distribution` | interval details for the effect size |
-| `bf10`, `log_e_bf10`, `prior.*` | Bayes factor, its log, and the prior (Bayesian only) |
-| `n.obs` | number of observations |
-| `expression` | plotmath expression with the test details |
+| Column                                                                    | Description                                                          |
+| :------------------------------------------------------------------------ | :------------------------------------------------------------------- |
+| `mu`                                                                      | the null value the mean is tested against (`test.value`)             |
+| `statistic`, `df.error`, `p.value`                                        | test statistic, its degrees of freedom, and *p*-value (non-Bayesian) |
+| `effectsize`, `estimate`                                                  | name and value of the effect size (e.g. Hedges' *g*)                 |
+| `conf.level`, `conf.low`, `conf.high`, `conf.method`, `conf.distribution` | interval details for the effect size                                 |
+| `bf10`, `log_e_bf10`, `prior.*`                                           | Bayes factor, its log, and the prior (Bayesian only)                 |
+| `n.obs`                                                                   | number of observations                                               |
+| `expression`                                                              | plotmath expression with the test details                            |
 
 ### `two_sample_test()`
 
@@ -163,13 +163,13 @@ set.seed(123)
 two_sample_test(ToothGrowth, supp, len) |> dplyr::glimpse()
 ```
 
-| Column | Description |
-| :----- | :---------- |
-| `parameter1`, `parameter2` | the outcome and grouping variable names |
-| `mean.parameter1`, `mean.parameter2` | group means (parametric between-subjects) |
-| `statistic`, `df.error`, `p.value` | test statistic, its degrees of freedom, and *p*-value |
-| `effectsize`, `estimate`, `conf.*` | effect size and its interval |
-| `n.obs`, `expression` | sample size and the plotmath expression |
+| Column                               | Description                                           |
+| :----------------------------------- | :---------------------------------------------------- |
+| `parameter1`, `parameter2`           | the outcome and grouping variable names               |
+| `mean.parameter1`, `mean.parameter2` | group means (parametric between-subjects)             |
+| `statistic`, `df.error`, `p.value`   | test statistic, its degrees of freedom, and *p*-value |
+| `effectsize`, `estimate`, `conf.*`   | effect size and its interval                          |
+| `n.obs`, `expression`                | sample size and the plotmath expression               |
 
 ### `oneway_anova()`
 
@@ -179,11 +179,11 @@ set.seed(123)
 oneway_anova(iris, Species, Sepal.Length) |> dplyr::glimpse()
 ```
 
-| Column | Description |
-| :----- | :---------- |
+| Column                                   | Description                                                  |
+| :--------------------------------------- | :----------------------------------------------------------- |
 | `statistic`, `df`, `df.error`, `p.value` | *F*-statistic with its two degrees of freedom, and *p*-value |
-| `effectsize`, `estimate`, `conf.*` | effect size (e.g. omega-squared) and its interval |
-| `n.obs`, `expression` | sample size and the plotmath expression |
+| `effectsize`, `estimate`, `conf.*`       | effect size (e.g. omega-squared) and its interval            |
+| `n.obs`, `expression`                    | sample size and the plotmath expression                      |
 
 For a two-degrees-of-freedom statistic like ANOVA, note that **both** `df` and
 `df.error` are present.
@@ -196,13 +196,13 @@ set.seed(123)
 corr_test(mtcars, wt, mpg) |> dplyr::glimpse()
 ```
 
-| Column | Description |
-| :----- | :---------- |
-| `parameter1`, `parameter2` | the two correlated variable names |
-| `effectsize`, `estimate` | name (e.g. Pearson's *r*) and value of the correlation |
-| `conf.level`, `conf.low`, `conf.high`, `conf.method` | interval details |
-| `statistic`, `df.error`, `p.value` | test statistic, degrees of freedom, and *p*-value |
-| `n.obs`, `expression` | sample size and the plotmath expression |
+| Column                                               | Description                                            |
+| :--------------------------------------------------- | :----------------------------------------------------- |
+| `parameter1`, `parameter2`                           | the two correlated variable names                      |
+| `effectsize`, `estimate`                             | name (e.g. Pearson's *r*) and value of the correlation |
+| `conf.level`, `conf.low`, `conf.high`, `conf.method` | interval details                                       |
+| `statistic`, `df.error`, `p.value`                   | test statistic, degrees of freedom, and *p*-value      |
+| `n.obs`, `expression`                                | sample size and the plotmath expression                |
 
 ### `contingency_table()`
 
@@ -217,12 +217,12 @@ set.seed(123)
 contingency_table(as.data.frame(HairEyeColor), Eye, counts = Freq) |> dplyr::glimpse()
 ```
 
-| Column | Description |
-| :----- | :---------- |
-| `statistic`, `df`, `p.value` | chi-squared statistic, its degrees of freedom, and *p*-value |
-| `effectsize`, `estimate`, `conf.*` | effect size (e.g. Cramer's *V*) and its interval |
-| `bf10`, `prior.scale` | Bayes factor and prior (Bayesian only) |
-| `n.obs`, `expression` | sample size and the plotmath expression |
+| Column                             | Description                                                  |
+| :--------------------------------- | :----------------------------------------------------------- |
+| `statistic`, `df`, `p.value`       | chi-squared statistic, its degrees of freedom, and *p*-value |
+| `effectsize`, `estimate`, `conf.*` | effect size (e.g. Cramer's *V*) and its interval             |
+| `bf10`, `prior.scale`              | Bayes factor and prior (Bayesian only)                       |
+| `n.obs`, `expression`              | sample size and the plotmath expression                      |
 
 ### `pairwise_comparisons()`
 
@@ -236,12 +236,12 @@ pairwise_comparisons(
 ) |> dplyr::glimpse()
 ```
 
-| Column | Description |
-| :----- | :---------- |
-| `group1`, `group2` | the two levels being compared |
-| `statistic`, `p.value` | test statistic and *p*-value for the comparison |
+| Column                    | Description                                             |
+| :------------------------ | :------------------------------------------------------ |
+| `group1`, `group2`        | the two levels being compared                           |
+| `statistic`, `p.value`    | test statistic and *p*-value for the comparison         |
 | `p.adjust.method`, `test` | multiple-comparison adjustment method and the test used |
-| `expression` | plotmath expression with the (adjusted) *p*-value |
+| `expression`              | plotmath expression with the (adjusted) *p*-value       |
 
 Unlike the single-test functions, this returns **one row per pairwise comparison**.
 
@@ -253,11 +253,11 @@ set.seed(123)
 pairwise_contingency_table(mtcars, cyl, am, p.adjust.method = "holm") |> dplyr::glimpse()
 ```
 
-| Column | Description |
-| :----- | :---------- |
-| `group1`, `group2` | the two levels being compared |
-| `p.value`, `p.value.adj` | unadjusted and multiplicity-adjusted *p*-values |
-| `effectsize`, `estimate`, `conf.*` | Cramer's *V* effect size and its interval |
+| Column                                  | Description                                      |
+| :-------------------------------------- | :----------------------------------------------- |
+| `group1`, `group2`                      | the two levels being compared                    |
+| `p.value`, `p.value.adj`                | unadjusted and multiplicity-adjusted *p*-values  |
+| `effectsize`, `estimate`, `conf.*`      | Cramer's *V* effect size and its interval        |
 | `p.adjust.method`, `test`, `expression` | adjustment method, test, and plotmath expression |
 
 ### `meta_analysis()`
@@ -272,13 +272,13 @@ set.seed(123)
 meta_analysis(df) |> dplyr::glimpse()
 ```
 
-| Column | Description |
-| :----- | :---------- |
-| `term`, `effectsize` | the summary term and effect-size label |
-| `estimate`, `std.error` | meta-analytic summary estimate and its standard error |
-| `conf.level`, `conf.low`, `conf.high`, `conf.method` | interval details |
-| `statistic`, `p.value` | test statistic and *p*-value |
-| `n.obs`, `expression` | number of studies and the plotmath expression |
+| Column                                               | Description                                           |
+| :--------------------------------------------------- | :---------------------------------------------------- |
+| `term`, `effectsize`                                 | the summary term and effect-size label                |
+| `estimate`, `std.error`                              | meta-analytic summary estimate and its standard error |
+| `conf.level`, `conf.low`, `conf.high`, `conf.method` | interval details                                      |
+| `statistic`, `p.value`                               | test statistic and *p*-value                          |
+| `n.obs`, `expression`                                | number of studies and the plotmath expression         |
 
 ### `centrality_description()`
 
@@ -288,15 +288,15 @@ set.seed(123)
 centrality_description(iris, Species, Sepal.Length) |> dplyr::glimpse()
 ```
 
-| Column | Description |
-| :----- | :---------- |
-| `<x>` (e.g. `Species`) | the grouping variable |
-| `<y>` (e.g. `Sepal.Length`) | the requested centrality measure (mean/median/trimmed mean/MAP) |
-| `std.dev`, `iqr`, `min`, `max`, `skewness`, `kurtosis` | dispersion and shape statistics |
-| `conf.low`, `conf.high` | interval for the centrality estimate |
-| `n.obs`, `missing.obs` | count of observations and missing values |
-| `expression` | plotmath expression with the centrality estimate |
-| `n.expression` | a label combining the group name and its sample size (handy as a facet/axis label) |
+| Column                                                 | Description                                                                        |
+| :----------------------------------------------------- | :--------------------------------------------------------------------------------- |
+| `<x>` (e.g. `Species`)                                 | the grouping variable                                                              |
+| `<y>` (e.g. `Sepal.Length`)                            | the requested centrality measure (mean/median/trimmed mean/MAP)                    |
+| `std.dev`, `iqr`, `min`, `max`, `skewness`, `kurtosis` | dispersion and shape statistics                                                    |
+| `conf.low`, `conf.high`                                | interval for the centrality estimate                                               |
+| `n.obs`, `missing.obs`                                 | count of observations and missing values                                           |
+| `expression`                                           | plotmath expression with the centrality estimate                                   |
+| `n.expression`                                         | a label combining the group name and its sample size (handy as a facet/axis label) |
 
 This is the only function that returns an `n.expression` column.
 

--- a/vignettes/web_only/return_value_schema.Rmd
+++ b/vignettes/web_only/return_value_schema.Rmd
@@ -50,37 +50,43 @@ Two design principles are worth keeping in mind while reading this article:
 
 1.  **The exact columns depend on the analysis.** All functions follow the same
     tidy/[`{broom}`](https://broom.tidymodels.org/)-style naming conventions, but
-    the precise set of columns returned depends on both the *test* and the *type*
-    of analysis (`"parametric"`, `"nonparametric"`, `"robust"`, or `"bayes"`). For
-    example, Bayesian analyses return Bayes-factor columns (`bf10`, `log_e_bf10`)
-    that frequentist analyses do not.
+    the precise set of columns returned depends on the test and, for functions
+    that accept a `type` argument, on the chosen analysis (`"parametric"`,
+    `"nonparametric"`, `"robust"`, or `"bayes"`). For example, most Bayesian
+    analyses return Bayes-factor columns (`bf10`, and usually `log_e_bf10`) that
+    frequentist analyses do not.
 
 2.  **The `expression` column is the core deliverable.** Regardless of the test,
     almost every function returns a pre-formatted `expression` column intended for
     annotating plots. This is what powers the statistical details you see in
     [`{ggstatsplot}`](https://indrajeetpatil.github.io/ggstatsplot/) plots.
 
-The rest of this article documents the `expression` column, the internal engine
-that builds it, and then provides a column-by-column schema for each exported
-function.
+The rest of this article documents the `expression` column, the engine that
+builds it, and then provides a schema for each exported function. Because the
+precise columns vary with the test and `type`, the tables below describe the
+*representative* columns you can expect; the accompanying `dplyr::glimpse()`
+output is the authoritative list for each call. Where a column is specific to a
+particular `type`, this is called out in the notes.
 
 ## The `expression` column
 
-The `expression` column is not a character string. It is a
-[plotmath](https://rdrr.io/r/grDevices/plotmath.html) `language` object, which is
-why it can render mathematical notation (subscripts, Greek letters, italicized
-statistics) when used as a plot label.
+The `expression` column is a **list-column**: each element is a
+[plotmath](https://rdrr.io/r/grDevices/plotmath.html) `language` object (not a
+character string), which is why it can render mathematical notation (subscripts,
+Greek letters, italicized statistics) when used as a plot label. Extract a single
+element with `[[` before using it.
 
 ```{r}
 #| label = "expression-class"
 set.seed(123)
 res <- two_sample_test(ToothGrowth, supp, len)
 
-# the column is a list of `language` objects, not strings
+# the column is a list; each element is a `language` object, not a string
+class(res$expression)
 class(res$expression[[1]])
 ```
 
-Because it is a `language` object, it can be dropped directly into any
+Because each element is a `language` object, it can be dropped directly into any
 `{ggplot2}` layer that accepts a plotmath expression, such as `labs()`,
 `annotate()`, or `ggtitle()`:
 
@@ -96,9 +102,11 @@ ggplot(ToothGrowth, aes(supp, len)) +
 
 ## The `add_expression_col()` engine
 
-All of the `expression` columns are produced by a single internal engine:
-`add_expression_col()`. Understanding it helps clarify why the output looks the
-way it does.
+Most of the `expression` columns are produced by a single internal engine:
+`add_expression_col()`. It is the main path for the hypothesis-testing functions
+(`one_sample_test()`, `two_sample_test()`, `oneway_anova()`, `corr_test()`,
+`contingency_table()`, `meta_analysis()`). Understanding it helps clarify why the
+output looks the way it does.
 
 The engine works as follows:
 
@@ -122,8 +130,16 @@ The engine works as follows:
     [`{glue}`](https://glue.tidyverse.org/), converts it to a `language` object,
     and appends it as the `expression` column.
 
+Not every function routes through this engine. `centrality_description()`,
+`pairwise_comparisons()`, and `pairwise_contingency_table()` build their own
+`{glue}` templates and call the shared `.glue_to_expression()` helper directly to
+attach the `expression` column. The end result is the same kind of list-column of
+plotmath expressions, but the assembly path is specialized rather than going
+through `add_expression_col()`.
+
 > **Note:** `add_expression_col()` is exported so that its behavior is documented
-> and inspectable, but it is **not stable** and is intended for internal use only.
+> and can be inspected, but it is **not stable** and is intended for internal use
+> only.
 > Its signature and behavior may change without a deprecation cycle. Build
 > downstream code against the *output columns* documented here rather than by
 > calling this function directly.
@@ -131,7 +147,9 @@ The engine works as follows:
 ## Per-function schema
 
 The examples below use `dplyr::glimpse()` so that every returned column (and its
-type) is visible at a glance.
+type) is visible at a glance. The tables list the *representative* columns; the
+`glimpse()` output is authoritative for any given call, and type-specific
+differences are noted below each table.
 
 ### `one_sample_test()`
 
@@ -155,6 +173,10 @@ one_sample_test(mtcars, wt, test.value = 3, type = "bayes") |> dplyr::glimpse()
 | `n.obs`                                                                   | number of observations                                               |
 | `expression`                                                              | plotmath expression with the test details                            |
 
+The Bayesian variant (`type = "bayes"`) replaces `statistic`/`df.error`/`p.value`
+with `term`, `pd`, `bf10`, `log_e_bf10`, and the `prior.*` columns, as the second
+`glimpse()` above shows.
+
 ### `two_sample_test()`
 
 ```{r}
@@ -171,6 +193,10 @@ two_sample_test(ToothGrowth, supp, len) |> dplyr::glimpse()
 | `effectsize`, `estimate`, `conf.*`   | effect size and its interval                          |
 | `n.obs`, `expression`                | sample size and the plotmath expression               |
 
+As with `one_sample_test()`, the Bayesian variant returns `term`, `pd`, `bf10`,
+`log_e_bf10`, and `prior.*` in place of the frequentist test statistic and
+*p*-value.
+
 ### `oneway_anova()`
 
 ```{r}
@@ -186,7 +212,10 @@ oneway_anova(iris, Species, Sepal.Length) |> dplyr::glimpse()
 | `n.obs`, `expression`                    | sample size and the plotmath expression                      |
 
 For a two-degrees-of-freedom statistic like ANOVA, note that **both** `df` and
-`df.error` are present.
+`df.error` are present. The non-parametric variant (`type = "np"`) instead
+returns a single-parameter statistic with `parameter1`/`parameter2` and a
+`conf.iterations` column (the number of bootstrap iterations), while the Bayesian
+variant returns the usual `bf10`/`log_e_bf10`/`prior.*` columns.
 
 ### `corr_test()`
 
@@ -203,6 +232,9 @@ corr_test(mtcars, wt, mpg) |> dplyr::glimpse()
 | `conf.level`, `conf.low`, `conf.high`, `conf.method` | interval details                                       |
 | `statistic`, `df.error`, `p.value`                   | test statistic, degrees of freedom, and *p*-value      |
 | `n.obs`, `expression`                                | sample size and the plotmath expression                |
+
+The Bayesian variant adds `bf10`, `log_e_bf10`, `pd`, `rope.percentage`, and the
+`prior.*` columns.
 
 ### `contingency_table()`
 
@@ -224,6 +256,13 @@ contingency_table(as.data.frame(HairEyeColor), Eye, counts = Freq) |> dplyr::gli
 | `bf10`, `prior.scale`              | Bayes factor and prior (Bayesian only)                       |
 | `n.obs`, `expression`              | sample size and the plotmath expression                      |
 
+The two Bayesian paths differ in their columns. The **two-way** Bayesian analysis
+returns the full set of Bayesian columns (`term`, `bf10`, `log_e_bf10`,
+`prior.distribution`/`prior.location`/`prior.scale`, plus the effect-size
+interval). The **one-way** (goodness-of-fit) Bayesian analysis is more minimal,
+returning only `bf10`, `prior.scale`, `method`, and `expression` -- in particular
+it does **not** include a `log_e_bf10` column.
+
 ### `pairwise_comparisons()`
 
 ```{r}
@@ -239,11 +278,15 @@ pairwise_comparisons(
 | Column                    | Description                                             |
 | :------------------------ | :------------------------------------------------------ |
 | `group1`, `group2`        | the two levels being compared                           |
-| `statistic`, `p.value`    | test statistic and *p*-value for the comparison         |
+| `statistic`, `p.value`    | test statistic and the (adjusted) *p*-value             |
 | `p.adjust.method`, `test` | multiple-comparison adjustment method and the test used |
 | `expression`              | plotmath expression with the (adjusted) *p*-value       |
 
-Unlike the single-test functions, this returns **one row per pairwise comparison**.
+Unlike the single-test functions, this returns **one row per pairwise
+comparison**. Note that the adjusted *p*-value is folded directly into the
+`p.value` column here (there is no separate `p.value.adj` column, unlike in
+`pairwise_contingency_table()`). The Bayesian variant additionally returns
+`estimate`, `bf10`, `log_e_bf10`, and the `prior.*` columns.
 
 ### `pairwise_contingency_table()`
 
@@ -277,8 +320,12 @@ meta_analysis(df) |> dplyr::glimpse()
 | `term`, `effectsize`                                 | the summary term and effect-size label                |
 | `estimate`, `std.error`                              | meta-analytic summary estimate and its standard error |
 | `conf.level`, `conf.low`, `conf.high`, `conf.method` | interval details                                      |
-| `statistic`, `p.value`                               | test statistic and *p*-value                          |
+| `statistic`, `p.value`, `weight`                     | test statistic, *p*-value, and study weight           |
 | `n.obs`, `expression`                                | number of studies and the plotmath expression         |
+
+The Bayesian variant additionally returns MCMC diagnostics and Bayes-factor
+columns: `bf10`, `log_e_bf10`, `rhat`, `ess`, `component`, and the `prior.*`
+columns.
 
 ### `centrality_description()`
 
@@ -288,17 +335,19 @@ set.seed(123)
 centrality_description(iris, Species, Sepal.Length) |> dplyr::glimpse()
 ```
 
-| Column                                                 | Description                                                                        |
-| :----------------------------------------------------- | :--------------------------------------------------------------------------------- |
-| `<x>` (e.g. `Species`)                                 | the grouping variable                                                              |
-| `<y>` (e.g. `Sepal.Length`)                            | the requested centrality measure (mean/median/trimmed mean/MAP)                    |
-| `std.dev`, `iqr`, `min`, `max`, `skewness`, `kurtosis` | dispersion and shape statistics                                                    |
-| `conf.low`, `conf.high`                                | interval for the centrality estimate                                               |
-| `n.obs`, `missing.obs`                                 | count of observations and missing values                                           |
-| `expression`                                           | plotmath expression with the centrality estimate                                   |
-| `n.expression`                                         | a label combining the group name and its sample size (handy as a facet/axis label) |
+| Column                                                        | Description                                                                        |
+| :------------------------------------------------------------ | :--------------------------------------------------------------------------------- |
+| `<x>` (e.g. `Species`)                                        | the grouping variable                                                              |
+| `<y>` (e.g. `Sepal.Length`)                                   | the requested centrality measure (mean/median/trimmed mean/MAP)                    |
+| `std.dev` or `mad`, `iqr`, `min`, `max`, `skewness`, `kurtosis` | dispersion and shape statistics                                                  |
+| `conf.low`, `conf.high`                                       | interval for the centrality estimate                                               |
+| `n.obs`, `missing.obs`                                        | count of observations and missing values                                           |
+| `expression`                                                  | plotmath expression with the centrality estimate                                   |
+| `n.expression`                                                | a label combining the group name and its sample size (handy as a facet/axis label) |
 
-This is the only function that returns an `n.expression` column.
+The dispersion column depends on `type`: `std.dev` for `"parametric"` and
+`"robust"`, `mad` (median absolute deviation) for `"nonparametric"`, and neither
+for `"bayes"`. This is the only function that returns an `n.expression` column.
 
 ## Suggestions
 

--- a/vignettes/web_only/return_value_schema.Rmd
+++ b/vignettes/web_only/return_value_schema.Rmd
@@ -1,0 +1,305 @@
+---
+title: "Return value schema"
+output:
+  rmarkdown::html_vignette:
+    toc: true
+    toc_depth: 4
+vignette: >
+  %\VignetteIndexEntry{Return value schema}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r}
+#| label = "setup",
+#| message = FALSE,
+#| warning = FALSE,
+#| include = FALSE,
+#| echo = FALSE
+source("../setup.R")
+
+pkgs <- c("metaplus", "metafor", "metaBMA")
+
+successfully_loaded <- purrr::map_lgl(pkgs, requireNamespace, quietly = TRUE)
+can_evaluate <- all(successfully_loaded)
+
+if (can_evaluate) {
+  purrr::walk(pkgs, library, character.only = TRUE)
+} else {
+  knitr::opts_chunk$set(eval = FALSE)
+}
+```
+
+This vignette can be cited as:
+
+```{r}
+#| label = "citation",
+#| echo = FALSE,
+#| comment = ""
+citation("statsExpressions")
+```
+
+## Introduction
+
+Every exported analysis function in `{statsExpressions}` returns a **tidy tibble**
+(with the additional class `"statsExpressions"`) rather than a model object. This
+means the output is immediately pipe-friendly and ready for downstream use in data
+wrangling or graphing pipelines.
+
+Two design principles are worth keeping in mind while reading this article:
+
+1.  **The exact columns depend on the analysis.** All functions follow the same
+    tidy/[`{broom}`](https://broom.tidymodels.org/)-style naming conventions, but
+    the precise set of columns returned depends on both the *test* and the *type*
+    of analysis (`"parametric"`, `"nonparametric"`, `"robust"`, or `"bayes"`). For
+    example, Bayesian analyses return Bayes-factor columns (`bf10`, `log_e_bf10`)
+    that frequentist analyses do not.
+
+2.  **The `expression` column is the core deliverable.** Regardless of the test,
+    almost every function returns a pre-formatted `expression` column intended for
+    annotating plots. This is what powers the statistical details you see in
+    [`{ggstatsplot}`](https://indrajeetpatil.github.io/ggstatsplot/) plots.
+
+The rest of this article documents the `expression` column, the internal engine
+that builds it, and then provides a column-by-column schema for each exported
+function.
+
+## The `expression` column
+
+The `expression` column is not a character string. It is a
+[plotmath](https://rdrr.io/r/grDevices/plotmath.html) `language` object, which is
+why it can render mathematical notation (subscripts, Greek letters, italicized
+statistics) when used as a plot label.
+
+```{r}
+#| label = "expression-class"
+set.seed(123)
+res <- two_sample_test(ToothGrowth, supp, len)
+
+# the column is a list of `language` objects, not strings
+class(res$expression[[1]])
+```
+
+Because it is a `language` object, it can be dropped directly into any
+`{ggplot2}` layer that accepts a plotmath expression, such as `labs()`,
+`annotate()`, or `ggtitle()`:
+
+```{r}
+#| label = "expression-usage",
+#| eval = FALSE
+library(ggplot2)
+
+ggplot(ToothGrowth, aes(supp, len)) +
+  geom_boxplot() +
+  labs(subtitle = res$expression[[1]])
+```
+
+## The `add_expression_col()` engine
+
+All of the `expression` columns are produced by a single internal engine:
+`add_expression_col()`. Understanding it helps clarify why the output looks the
+way it does.
+
+The engine works as follows:
+
+-   It consumes a tidy data frame of statistical details -- ideally the output of
+    `tidy_model_parameters()`, which standardizes the results from the various
+    modeling backends (`{effectsize}`, `{parameters}`, `{BayesFactor}`, etc.) into
+    consistent column names.
+
+-   It inspects the available columns to decide which expression *template* to
+    use. The key branch points are:
+
+    -   whether the analysis is **Bayesian** (detected via the presence of a
+        `bf10` column), and
+
+    -   the number of **degrees-of-freedom parameters** present (`0`, `1`, or
+        `2`), which determines whether the statistic is displayed as, e.g.,
+        `t = ...`, `t(df) = ...`, or `F(df1, df2) = ...`.
+
+-   It then formats the numeric values (respecting the `digits`, `digits.df`, and
+    `digits.df.error` arguments), assembles the plotmath string via
+    [`{glue}`](https://glue.tidyverse.org/), converts it to a `language` object,
+    and appends it as the `expression` column.
+
+> **Note:** `add_expression_col()` is exported so that its behavior is documented
+> and inspectable, but it is **not stable** and is intended for internal use only.
+> Its signature and behavior may change without a deprecation cycle. Build
+> downstream code against the *output columns* documented here rather than by
+> calling this function directly.
+
+## Per-function schema
+
+The examples below use `dplyr::glimpse()` so that every returned column (and its
+type) is visible at a glance.
+
+### `one_sample_test()`
+
+```{r}
+#| label = "one-sample"
+set.seed(123)
+one_sample_test(mtcars, wt, test.value = 3) |> dplyr::glimpse()
+
+# Bayesian variant returns Bayes-factor columns instead of a test statistic
+set.seed(123)
+one_sample_test(mtcars, wt, test.value = 3, type = "bayes") |> dplyr::glimpse()
+```
+
+| Column | Description |
+| :----- | :---------- |
+| `mu` | the null value the mean is tested against (`test.value`) |
+| `statistic`, `df.error`, `p.value` | test statistic, its degrees of freedom, and *p*-value (non-Bayesian) |
+| `effectsize`, `estimate` | name and value of the effect size (e.g. Hedges' *g*) |
+| `conf.level`, `conf.low`, `conf.high`, `conf.method`, `conf.distribution` | interval details for the effect size |
+| `bf10`, `log_e_bf10`, `prior.*` | Bayes factor, its log, and the prior (Bayesian only) |
+| `n.obs` | number of observations |
+| `expression` | plotmath expression with the test details |
+
+### `two_sample_test()`
+
+```{r}
+#| label = "two-sample"
+set.seed(123)
+two_sample_test(ToothGrowth, supp, len) |> dplyr::glimpse()
+```
+
+| Column | Description |
+| :----- | :---------- |
+| `parameter1`, `parameter2` | the outcome and grouping variable names |
+| `mean.parameter1`, `mean.parameter2` | group means (parametric between-subjects) |
+| `statistic`, `df.error`, `p.value` | test statistic, its degrees of freedom, and *p*-value |
+| `effectsize`, `estimate`, `conf.*` | effect size and its interval |
+| `n.obs`, `expression` | sample size and the plotmath expression |
+
+### `oneway_anova()`
+
+```{r}
+#| label = "oneway-anova"
+set.seed(123)
+oneway_anova(iris, Species, Sepal.Length) |> dplyr::glimpse()
+```
+
+| Column | Description |
+| :----- | :---------- |
+| `statistic`, `df`, `df.error`, `p.value` | *F*-statistic with its two degrees of freedom, and *p*-value |
+| `effectsize`, `estimate`, `conf.*` | effect size (e.g. omega-squared) and its interval |
+| `n.obs`, `expression` | sample size and the plotmath expression |
+
+For a two-degrees-of-freedom statistic like ANOVA, note that **both** `df` and
+`df.error` are present.
+
+### `corr_test()`
+
+```{r}
+#| label = "corr-test"
+set.seed(123)
+corr_test(mtcars, wt, mpg) |> dplyr::glimpse()
+```
+
+| Column | Description |
+| :----- | :---------- |
+| `parameter1`, `parameter2` | the two correlated variable names |
+| `effectsize`, `estimate` | name (e.g. Pearson's *r*) and value of the correlation |
+| `conf.level`, `conf.low`, `conf.high`, `conf.method` | interval details |
+| `statistic`, `df.error`, `p.value` | test statistic, degrees of freedom, and *p*-value |
+| `n.obs`, `expression` | sample size and the plotmath expression |
+
+### `contingency_table()`
+
+```{r}
+#| label = "contingency"
+# two-way association test
+set.seed(123)
+contingency_table(mtcars, am, vs) |> dplyr::glimpse()
+
+# one-way goodness-of-fit test
+set.seed(123)
+contingency_table(as.data.frame(HairEyeColor), Eye, counts = Freq) |> dplyr::glimpse()
+```
+
+| Column | Description |
+| :----- | :---------- |
+| `statistic`, `df`, `p.value` | chi-squared statistic, its degrees of freedom, and *p*-value |
+| `effectsize`, `estimate`, `conf.*` | effect size (e.g. Cramer's *V*) and its interval |
+| `bf10`, `prior.scale` | Bayes factor and prior (Bayesian only) |
+| `n.obs`, `expression` | sample size and the plotmath expression |
+
+### `pairwise_comparisons()`
+
+```{r}
+#| label = "pairwise-comparisons"
+set.seed(123)
+pairwise_comparisons(
+  mtcars, cyl, wt,
+  type = "nonparametric",
+  p.adjust.method = "none"
+) |> dplyr::glimpse()
+```
+
+| Column | Description |
+| :----- | :---------- |
+| `group1`, `group2` | the two levels being compared |
+| `statistic`, `p.value` | test statistic and *p*-value for the comparison |
+| `p.adjust.method`, `test` | multiple-comparison adjustment method and the test used |
+| `expression` | plotmath expression with the (adjusted) *p*-value |
+
+Unlike the single-test functions, this returns **one row per pairwise comparison**.
+
+### `pairwise_contingency_table()`
+
+```{r}
+#| label = "pairwise-contingency"
+set.seed(123)
+pairwise_contingency_table(mtcars, cyl, am, p.adjust.method = "holm") |> dplyr::glimpse()
+```
+
+| Column | Description |
+| :----- | :---------- |
+| `group1`, `group2` | the two levels being compared |
+| `p.value`, `p.value.adj` | unadjusted and multiplicity-adjusted *p*-values |
+| `effectsize`, `estimate`, `conf.*` | Cramer's *V* effect size and its interval |
+| `p.adjust.method`, `test`, `expression` | adjustment method, test, and plotmath expression |
+
+### `meta_analysis()`
+
+```{r}
+#| label = "meta"
+# renaming columns to `{statsExpressions}` conventions
+data(mag, package = "metaplus")
+df <- dplyr::rename(mag, estimate = yi, std.error = sei)
+
+set.seed(123)
+meta_analysis(df) |> dplyr::glimpse()
+```
+
+| Column | Description |
+| :----- | :---------- |
+| `term`, `effectsize` | the summary term and effect-size label |
+| `estimate`, `std.error` | meta-analytic summary estimate and its standard error |
+| `conf.level`, `conf.low`, `conf.high`, `conf.method` | interval details |
+| `statistic`, `p.value` | test statistic and *p*-value |
+| `n.obs`, `expression` | number of studies and the plotmath expression |
+
+### `centrality_description()`
+
+```{r}
+#| label = "centrality"
+set.seed(123)
+centrality_description(iris, Species, Sepal.Length) |> dplyr::glimpse()
+```
+
+| Column | Description |
+| :----- | :---------- |
+| `<x>` (e.g. `Species`) | the grouping variable |
+| `<y>` (e.g. `Sepal.Length`) | the requested centrality measure (mean/median/trimmed mean/MAP) |
+| `std.dev`, `iqr`, `min`, `max`, `skewness`, `kurtosis` | dispersion and shape statistics |
+| `conf.low`, `conf.high` | interval for the centrality estimate |
+| `n.obs`, `missing.obs` | count of observations and missing values |
+| `expression` | plotmath expression with the centrality estimate |
+| `n.expression` | a label combining the group name and its sample size (handy as a facet/axis label) |
+
+This is the only function that returns an `n.expression` column.
+
+## Suggestions
+
+If you find any bugs or have any suggestions/remarks, please file an issue on GitHub: <https://github.com/IndrajeetPatil/statsExpressions/issues>


### PR DESCRIPTION
## Summary

Closes a documentation gap surfaced by Context7 analytics: users ask what columns each exported function returns, what the preformatted `expression`/`n.expression` columns are, and what the internal `add_expression_col()` engine does — answerable today only by reading source code.

- **New web-only article** `vignettes/web_only/return_value_schema.Rmd` with: an intro on the tidy-tibble output contract, a section on the plotmath `expression` `language` object, an explanation of the `add_expression_col()` engine, and a per-function column-by-column schema (runnable `glimpse()` examples + column tables) for all exported analysis functions.
- **Expanded the shared `@returns` fragment** (`man/rmd-fragments/return.Rmd`) that drives every function's help page: added previously undocumented columns (`bf10`, `log_e_bf10`, `prior.distribution`/`prior.scale`/`prior.location`, `group1`/`group2`, `p.value.adj`, `p.adjust.method`), grouped columns by purpose, clarified that `expression` is a plotmath `language` object (not a string), and cross-linked to the new article.
- **Added a `@returns` section to `centrality_description()`**, which previously had none.
- Regenerated all affected `.Rd` files and added a `NEWS.md` entry.

## Test plan

- [x] `roxygen2::roxygenise()` runs clean; the expanded `@returns` renders into all 9 `\value{}` blocks (the pre-existing `.mean_difference_effsize` link warning is unrelated).
- [x] `rmarkdown::render()` of the new vignette succeeds; all code chunks (including Bayesian, robust, pairwise, and meta-analysis) evaluate and the printed columns match the schema tables.
- [ ] pkgdown site builds with the new article listed under Articles.